### PR TITLE
fix: wrong destination path

### DIFF
--- a/.github/workflows/dispath.yml
+++ b/.github/workflows/dispath.yml
@@ -30,4 +30,3 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "eu-north-1"
           SOURCE_DIR: "dist/"
-          DEST_DIR: "/"


### PR DESCRIPTION
S3 is a bit special in the sense it creates a folder called `/` when having that as destdir causing the app to be reached from `https://intercom.app.eyevinn.technology//index.html` which is not what we want. This PR resolves this by using the default destination dir which is the root of the bucket.