### PR TITLE
fix: make chrome webrtc-internals usable

### DIFF
--- a/src/components/production-line/use-rtc-connection.ts
+++ b/src/components/production-line/use-rtc-connection.ts
@@ -141,7 +141,7 @@ export const useRtcConnection = ({
   audioElement,
 }: TRtcConnectionOptions) => {
   const [rtcPeerConnection] = useState<RTCPeerConnection>(
-    new RTCPeerConnection()
+    () => new RTCPeerConnection()
   );
   const [, dispatch] = useGlobalState();
   const [connectionState, setConnectionState] =


### PR DESCRIPTION
Prevents multiple calls to new RtcPeerConnection
due to React semantics. The calls would normally
be GC'd and cause no problems, but in chrome webrtc iternals they are cached, creating new ones on
every re-render.

#18 