### PR TITLE
chore: continous deploy to dev bucket

### DIFF
--- a/.github/workflows/run-cd.yml
+++ b/.github/workflows/run-cd.yml
@@ -1,0 +1,35 @@
+name: Continous deploy to dev environment
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+
+      - name: Build
+        run: |
+          yarn
+          yarn build
+
+      - name: Sync to Dev bucket
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: "origin-intercom-app-dev"
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID  }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "eu-north-1"
+          SOURCE_DIR: "dist/"


### PR DESCRIPTION
This PR adds continuous deploy to a new bucket for development version of the app. The development version of the app will then be available at https://intercom-dev.app.eyevinn.technology/