### PR TITLE
fix: added min-width to warning-message

### DIFF
--- a/src/components/landing-page/form-elements.tsx
+++ b/src/components/landing-page/form-elements.tsx
@@ -50,7 +50,7 @@ export const StyledWarningMessage = styled.div`
   display: flex;
   align-items: center;
 
-  &.with-loader {
+  &.with-min-width {
     min-width: 27rem;
   }
 `;

--- a/src/components/landing-page/join-production.tsx
+++ b/src/components/landing-page/join-production.tsx
@@ -211,7 +211,7 @@ export const JoinProduction = ({ preSelected }: TProps) => {
                 ))}
               </FormSelect>
             ) : (
-              <StyledWarningMessage className="with-loader">
+              <StyledWarningMessage className="with-min-width">
                 Controlled by operating system
               </StyledWarningMessage>
             )}
@@ -238,7 +238,7 @@ export const JoinProduction = ({ preSelected }: TProps) => {
                   ))}
               </FormSelect>
               {!production && (
-                <StyledWarningMessage className="with-loader">
+                <StyledWarningMessage className="with-min-width">
                   Please enter a production id
                   {loading && <LoaderDots className="in-active" text="" />}
                 </StyledWarningMessage>

--- a/src/components/manage-productions/manage-productions.tsx
+++ b/src/components/manage-productions/manage-productions.tsx
@@ -200,7 +200,7 @@ export const ManageProductions = () => {
           )}
         </>
       ) : (
-        <StyledWarningMessage className="with-loader">
+        <StyledWarningMessage className="with-min-width">
           Please enter a production id
           {fetchLoader && <LoaderDots className="in-active" text="" />}
         </StyledWarningMessage>


### PR DESCRIPTION
width was changeing on iphone when production id had been entered, due to there always being the "output controlled by opterating system"-message and the screen being so small.