### PR TITLE
Feat/add and remove line from prod

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -122,6 +122,31 @@ export const API = {
         },
       })
     ),
+  addProductionLine: (productionId: number, name: string): Promise<TLine> =>
+    handleFetchRequest<TLine>(
+      fetch(`${API_URL}production/${productionId}/line`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {}),
+        },
+        body: JSON.stringify({
+          name,
+        }),
+      })
+    ),
+  deleteProductionLine: (
+    productionId: number,
+    lineId: number
+  ): Promise<string> =>
+    handleFetchRequest<string>(
+      fetch(`${API_URL}production/${productionId}/line/${lineId}`, {
+        method: "DELETE",
+        headers: {
+          ...(API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {}),
+        },
+      })
+    ),
   offerAudioSession: ({
     productionId,
     lineId,

--- a/src/components/landing-page/create-production.tsx
+++ b/src/components/landing-page/create-production.tsx
@@ -15,28 +15,14 @@ import {
 import { API } from "../../api/api.ts";
 import { useGlobalState } from "../../global-state/context-provider.tsx";
 import { Spinner } from "../loader/loader.tsx";
-import { RemoveIcon } from "../../assets/icons/icon.tsx";
 import { FlexContainer } from "../generic-components.ts";
+import { RemoveLineButton } from "../remove-line-button/remove-line-button.tsx";
 
 type FormValues = {
   productionName: string;
   defaultLine: string;
   lines: { name: string }[];
 };
-
-const RemoveLineBtn = styled.button`
-  cursor: pointer;
-  position: absolute;
-  top: -0.7rem;
-  right: -0.5rem;
-  padding: 1rem;
-  background: transparent;
-  border: transparent;
-`;
-
-const ButtonIcon = styled.div`
-  width: 2.5rem;
-`;
 
 const ListItemWrapper = styled.div`
   position: relative;
@@ -164,11 +150,7 @@ export const CreateProduction = () => {
                 placeholder="Line Name"
               />
               {index === fields.length - 1 && (
-                <RemoveLineBtn type="button" onClick={() => remove(index)}>
-                  <ButtonIcon>
-                    <RemoveIcon />
-                  </ButtonIcon>
-                </RemoveLineBtn>
+                <RemoveLineButton removeLine={() => remove(index)} />
               )}
             </ListItemWrapper>
           </FormLabel>

--- a/src/components/landing-page/use-fetch-production.ts
+++ b/src/components/landing-page/use-fetch-production.ts
@@ -2,13 +2,16 @@ import { useEffect, useState } from "react";
 import { API } from "../../api/api";
 import { TProduction } from "../production-line/types";
 
-type TUseFetchProduction = (id: number | null) => {
+type TUseFetchProduction = (
+  id: number | null,
+  refresh?: number
+) => {
   production: TProduction | null;
   error: Error | null;
   loading: boolean;
 };
 
-export const useFetchProduction: TUseFetchProduction = (id) => {
+export const useFetchProduction: TUseFetchProduction = (id, refresh) => {
   const [production, setProduction] = useState<TProduction | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
@@ -16,6 +19,7 @@ export const useFetchProduction: TUseFetchProduction = (id) => {
   useEffect(() => {
     let aborted = false;
     setLoading(true);
+    setProduction(null);
 
     if (id) {
       API.fetchProduction(id)
@@ -39,7 +43,7 @@ export const useFetchProduction: TUseFetchProduction = (id) => {
     return () => {
       aborted = true;
     };
-  }, [id]);
+  }, [id, refresh]);
 
   return {
     error,

--- a/src/components/manage-productions/manage-lines.tsx
+++ b/src/components/manage-productions/manage-lines.tsx
@@ -1,0 +1,234 @@
+import { SubmitHandler, useFieldArray, useForm } from "react-hook-form";
+import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import { ErrorMessage } from "@hookform/error-message";
+import { DisplayContainerHeader } from "../landing-page/display-container-header";
+import { TLine, TProduction } from "../production-line/types";
+import {
+  DecorativeLabel,
+  FormInput,
+  FormLabel,
+  PrimaryButton,
+  SecondaryButton,
+  StyledWarningMessage,
+} from "../landing-page/form-elements";
+import { FlexContainer } from "../generic-components";
+import { Spinner } from "../loader/loader";
+import { useRemoveProductionLine } from "./use-remove-production-line";
+import { useAddProductionLine } from "./use-add-production-line";
+import { RemoveLineButton } from "../remove-line-button/remove-line-button";
+
+type TManageLines = {
+  production: TProduction;
+  updateProduction: () => void;
+};
+
+type FormValues = {
+  lines: { name: string }[];
+};
+
+type TLastItem = {
+  lastItem: boolean;
+};
+
+const Container = styled.div`
+  max-width: 45rem;
+  min-width: 35rem;
+  padding: 2rem;
+  margin-right: 2rem;
+  border-radius: 1rem;
+  border: 0.2rem solid #434343;
+`;
+
+const NewLineWrapper = styled.div`
+  position: relative;
+`;
+
+const ListItemWrapper = styled.div<TLastItem>`
+  position: relative;
+  padding: 0.5rem 0;
+
+  &:hover {
+    background-color: #434343;
+    border-radius: 0.2rem;
+  }
+
+  ${({ lastItem }) => (lastItem ? `margin-bottom: 2rem;` : "")}
+`;
+
+const LineItem = styled(DecorativeLabel)`
+  padding: 0 1rem 0 0;
+`;
+
+const ConfirmButton = styled.button`
+  cursor: pointer;
+  position: absolute;
+  top: 1.5rem;
+  right: 2.5rem;
+  z-index: 100;
+
+  &:hover:active {
+    transform: scale(1.1);
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  margin: 0 1rem 1rem 0;
+  :last-of-type {
+    margin: 0 0 1rem;
+  }
+`;
+
+export const ManageLines = ({ production, updateProduction }: TManageLines) => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [removeActive, setRemoveActive] = useState<boolean>(false);
+  const [updateLines, setUpdateLines] = useState<FormValues | null>(null);
+  const [verifyRemove, setVerifyRemove] = useState<null | string>(null);
+  const [removeId, setRemoveId] = useState<null | number>(null);
+  const productionIdToNumber = parseInt(production.productionId, 10);
+
+  const {
+    formState: { errors },
+    control,
+    register,
+    handleSubmit,
+    reset,
+  } = useForm<FormValues>();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "lines",
+    rules: {
+      minLength: 1,
+    },
+  });
+
+  const { loading: fetchInProgress, successfullCreate } = useAddProductionLine(
+    productionIdToNumber,
+    updateLines
+  );
+
+  const { loading: deleteInProgress, successfullDelete } =
+    useRemoveProductionLine(productionIdToNumber, removeId);
+
+  const onSubmit: SubmitHandler<FormValues> = (value) => {
+    if (fetchInProgress) return;
+
+    setLoading(true);
+    setUpdateLines(value);
+  };
+
+  // Reset form values when created production id changes
+  useEffect(() => {
+    if (successfullCreate || successfullDelete) {
+      reset({
+        lines: [],
+      });
+      setRemoveId(null);
+      setVerifyRemove(null);
+      setLoading(false);
+      setRemoveActive(false);
+      updateProduction();
+    }
+  }, [reset, successfullCreate, successfullDelete, updateProduction]);
+
+  return (
+    <Container>
+      <DisplayContainerHeader>Manage Lines</DisplayContainerHeader>
+      {production.lines.map((singleLine: TLine, index) => (
+        <ListItemWrapper
+          key={singleLine.id}
+          lastItem={
+            production.lines.length === index + 1 && fields.length === 0
+          }
+        >
+          <LineItem>{singleLine.name}</LineItem>
+          {removeActive && (
+            <RemoveLineButton
+              removeLine={() =>
+                !verifyRemove
+                  ? setVerifyRemove(singleLine.id)
+                  : setVerifyRemove(null)
+              }
+            />
+          )}
+          {verifyRemove === singleLine.id && (
+            <ConfirmButton
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                setRemoveId(parseInt(singleLine.id, 10));
+              }}
+            >
+              remove {singleLine.name}
+            </ConfirmButton>
+          )}
+        </ListItemWrapper>
+      ))}
+      {fields.map((field, index) => (
+        <div key={field.id}>
+          <FormLabel>
+            <NewLineWrapper>
+              <FormInput
+                // eslint-disable-next-line
+                {...register(`lines.${index}.name`, {
+                  required: "Line name is required",
+                  minLength: 1,
+                })}
+                className="additional-line"
+                autoComplete="off"
+                placeholder="Line Name"
+              />
+              {index === fields.length - 1 && (
+                <RemoveLineButton removeLine={() => remove(0)} />
+              )}
+            </NewLineWrapper>
+          </FormLabel>
+          <ErrorMessage
+            errors={errors}
+            name={`lines.${index}.name`}
+            as={StyledWarningMessage}
+          />
+        </div>
+      ))}
+      <FlexContainer>
+        <ButtonWrapper>
+          <SecondaryButton
+            type="button"
+            disabled={fields.length !== 0}
+            onClick={() => {
+              setVerifyRemove(null);
+              append({ name: "" });
+            }}
+          >
+            Create Line
+          </SecondaryButton>
+        </ButtonWrapper>
+        <ButtonWrapper>
+          <SecondaryButton
+            type="button"
+            className={deleteInProgress ? "with-loader" : ""}
+            onClick={() => {
+              setVerifyRemove(null);
+              setRemoveActive(!removeActive);
+            }}
+          >
+            Remove Line
+            {deleteInProgress && <Spinner className="create-production" />}
+          </SecondaryButton>
+        </ButtonWrapper>
+        {fields.length !== 0 && (
+          <ButtonWrapper>
+            <PrimaryButton
+              type="submit"
+              className={loading ? "with-loader" : ""}
+              onClick={handleSubmit(onSubmit)}
+            >
+              Save Changes
+              {loading && <Spinner className="create-production" />}
+            </PrimaryButton>
+          </ButtonWrapper>
+        )}
+      </FlexContainer>
+    </Container>
+  );
+};

--- a/src/components/manage-productions/remove-production.tsx
+++ b/src/components/manage-productions/remove-production.tsx
@@ -1,0 +1,93 @@
+import styled from "@emotion/styled";
+import { DisplayContainerHeader } from "../landing-page/display-container-header";
+import { PrimaryButton } from "../landing-page/form-elements";
+import { Spinner } from "../loader/loader";
+
+const Container = styled.div`
+  max-width: 45rem;
+  min-width: 35rem;
+  padding: 2rem;
+  border-radius: 1rem;
+  border: 0.2rem solid #434343;
+`;
+
+const VerifyBtnWrapper = styled.div`
+  margin: 3rem 0 2rem 2rem;
+`;
+
+const VerifyButtons = styled.div`
+  display: flex;
+  padding: 1rem 0 0 0;
+`;
+
+const Button = styled(PrimaryButton)`
+  margin: 0 1rem 0 0;
+`;
+
+const ButtonWrapper = styled.div`
+  margin: 2rem 0 2rem 0;
+`;
+
+type TRemoveProduction = {
+  deleteLoader: boolean;
+  handleSubmit: () => void;
+  verifyRemove: boolean;
+  setVerifyRemove: (input: boolean) => void;
+  reset: () => void;
+};
+
+export const RemoveProduction = ({
+  deleteLoader,
+  handleSubmit,
+  verifyRemove,
+  setVerifyRemove,
+  reset,
+}: TRemoveProduction) => {
+  return (
+    <Container>
+      <DisplayContainerHeader>Remove Production</DisplayContainerHeader>
+      {!verifyRemove && (
+        <ButtonWrapper>
+          <PrimaryButton
+            type="button"
+            className={deleteLoader ? "submit" : ""}
+            onClick={() => {
+              setVerifyRemove(true);
+            }}
+          >
+            Remove
+            {deleteLoader && <Spinner className="manage-production" />}
+          </PrimaryButton>
+        </ButtonWrapper>
+      )}
+      {verifyRemove && (
+        <VerifyBtnWrapper>
+          <p>Are you sure?</p>
+          <VerifyButtons>
+            <Button
+              type="button"
+              className={deleteLoader ? "submit" : ""}
+              disabled={deleteLoader}
+              onClick={() => {
+                handleSubmit();
+              }}
+            >
+              Yes
+              {deleteLoader && <Spinner className="manage-production" />}
+            </Button>
+            <Button
+              type="button"
+              className={deleteLoader ? "submit" : ""}
+              onClick={() => {
+                reset();
+              }}
+            >
+              Go back
+              {deleteLoader && <Spinner className="manage-production" />}
+            </Button>
+          </VerifyButtons>
+        </VerifyBtnWrapper>
+      )}
+    </Container>
+  );
+};

--- a/src/components/manage-productions/use-add-production-line.ts
+++ b/src/components/manage-productions/use-add-production-line.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { API } from "../../api/api";
+import { useGlobalState } from "../../global-state/context-provider";
+
+type TUseDeleteProduction = (
+  productionId: number | null,
+  lineNames: {
+    lines: { name: string }[];
+  } | null
+) => {
+  loading: boolean;
+  successfullCreate: boolean;
+};
+
+export const useAddProductionLine: TUseDeleteProduction = (
+  productionId,
+  lineNames
+) => {
+  const [successfullCreate, setSuccessfullCreate] = useState(false);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const [, dispatch] = useGlobalState();
+
+  useEffect(() => {
+    let aborted = false;
+    setSuccessfullCreate(false);
+    setLoading(true);
+    if (productionId && lineNames) {
+      API.addProductionLine(productionId, lineNames.lines[0].name)
+        .then(() => {
+          if (aborted) return;
+
+          setSuccessfullCreate(true);
+          setLoading(false);
+        })
+        .catch((err) => {
+          dispatch({
+            type: "ERROR",
+            payload:
+              err instanceof Error
+                ? err
+                : new Error("Failed to create production line"),
+          });
+          setLoading(false);
+        });
+    } else {
+      setLoading(false);
+    }
+
+    return () => {
+      aborted = true;
+    };
+  }, [dispatch, lineNames, productionId]);
+
+  return {
+    loading,
+    successfullCreate,
+  };
+};

--- a/src/components/manage-productions/use-remove-production-line.ts
+++ b/src/components/manage-productions/use-remove-production-line.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { API } from "../../api/api";
+import { useGlobalState } from "../../global-state/context-provider";
+
+type TUseDeleteProduction = (
+  productionId: number | null,
+  lineId: number | null
+) => {
+  loading: boolean;
+  successfullDelete: boolean;
+};
+
+export const useRemoveProductionLine: TUseDeleteProduction = (
+  productionId,
+  lineId
+) => {
+  const [successfullDelete, setSuccessfullDelete] = useState(false);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const [, dispatch] = useGlobalState();
+
+  useEffect(() => {
+    let aborted = false;
+    setSuccessfullDelete(false);
+    setLoading(true);
+    if (productionId && lineId) {
+      API.deleteProductionLine(productionId, lineId)
+        .then(() => {
+          if (aborted) return;
+
+          setSuccessfullDelete(true);
+          setLoading(false);
+        })
+        .catch((err) => {
+          dispatch({
+            type: "ERROR",
+            payload:
+              err instanceof Error
+                ? err
+                : new Error("Failed to delete production line"),
+          });
+          setLoading(false);
+        });
+    } else {
+      setLoading(false);
+    }
+
+    return () => {
+      aborted = true;
+    };
+  }, [dispatch, lineId, productionId]);
+
+  return {
+    loading,
+    successfullDelete,
+  };
+};

--- a/src/components/remove-line-button/remove-line-button.tsx
+++ b/src/components/remove-line-button/remove-line-button.tsx
@@ -1,0 +1,30 @@
+import styled from "@emotion/styled";
+import { RemoveIcon } from "../../assets/icons/icon.tsx";
+
+const RemoveLineBtn = styled.button`
+  cursor: pointer;
+  position: absolute;
+  top: -0.7rem;
+  right: -0.5rem;
+  padding: 1rem;
+  background: transparent;
+  border: transparent;
+`;
+
+const ButtonIcon = styled.div`
+  width: 2.5rem;
+`;
+
+export const RemoveLineButton = ({
+  removeLine,
+}: {
+  removeLine: () => void;
+}) => {
+  return (
+    <RemoveLineBtn type="button" onClick={() => removeLine()}>
+      <ButtonIcon>
+        <RemoveIcon />
+      </ButtonIcon>
+    </RemoveLineBtn>
+  );
+};


### PR DESCRIPTION
# New structure of manage productions-page:
<img width="939" alt="Screenshot 2024-06-24 at 10 20 38" src="https://github.com/Eyevinn/intercom-frontend/assets/109201562/f72c2d36-9b8c-4db0-a527-130d5a8e93e1">


# View when pressing "create line"
when activated the "save"-button appears and "create line"-button is disabled:
<img width="1029" alt="Screenshot 2024-06-24 at 10 21 12" src="https://github.com/Eyevinn/intercom-frontend/assets/109201562/7b30fa3c-fb9f-4718-8902-6f17c1083677">

# View when pressing "remove line"
line is highlighted when hovered over to help user click on the right one:
<img width="978" alt="Screenshot 2024-06-24 at 10 20 52" src="https://github.com/Eyevinn/intercom-frontend/assets/109201562/a1ab4688-06bf-4ce5-b64a-6f0d074be5cb">

# When the "X" is pressed
the user needs to press aditional confirmation to delete:
<img width="922" alt="Screenshot 2024-06-24 at 10 26 05" src="https://github.com/Eyevinn/intercom-frontend/assets/109201562/83f0a565-6bc2-43f9-9ebd-aa46167d8e82">

