### PR TITLE
Feat/add productions list to manage view

### DIFF
--- a/src/components/landing-page/create-production.tsx
+++ b/src/components/landing-page/create-production.tsx
@@ -92,7 +92,7 @@ export const CreateProduction = () => {
         lines: [],
       });
       dispatch({
-        type: "PRODUCTION_CREATED",
+        type: "PRODUCTION_UPDATED",
       });
     }
   }, [createdProductionId, dispatch, reset]);

--- a/src/components/landing-page/landing-page.tsx
+++ b/src/components/landing-page/landing-page.tsx
@@ -1,6 +1,6 @@
 import { JoinProduction } from "./join-production.tsx";
 import { CreateProduction } from "./create-production.tsx";
-import { ProductionsList } from "./productions-list.tsx";
+import { ProductionsListContainer } from "./productions-list-container.tsx";
 import { useNavigateToProduction } from "./use-navigate-to-production.ts";
 import { DisplayContainer, FlexContainer } from "../generic-components.ts";
 import { useGlobalState } from "../../global-state/context-provider.tsx";
@@ -23,7 +23,7 @@ export const LandingPage = () => {
           </DisplayContainer>
         )}
       </FlexContainer>
-      <ProductionsList />
+      <ProductionsListContainer />
     </>
   );
 };

--- a/src/components/landing-page/productions-list-container.tsx
+++ b/src/components/landing-page/productions-list-container.tsx
@@ -6,41 +6,24 @@ import { useRefreshAnimation } from "./use-refresh-animation.ts";
 import { DisplayContainerHeader } from "./display-container-header.tsx";
 import { DisplayContainer } from "../generic-components.ts";
 import { ManageProductionButton } from "./manage-production-button.tsx";
-import { LocalError } from "../error.tsx";
 import { useFetchProductionList } from "./use-fetch-production-list.ts";
-
-const ProductionListContainer = styled.div`
-  display: flex;
-  padding: 0 0 2rem 2rem;
-  flex-wrap: wrap;
-`;
+import { ProductionsList } from "../productions-list.tsx";
 
 const HeaderContainer = styled(DisplayContainer)`
   padding: 0 2rem 0 2rem;
 `;
 
-const ProductionItem = styled.div`
-  flex: 1 0 calc(25% - 2rem);
-  min-width: 20rem;
-  border: 1px solid #424242;
-  border-radius: 0.5rem;
-  padding: 2rem;
-  margin: 0 2rem 2rem 0;
+const LoaderWrapper = styled.div`
+  padding-bottom: 1rem;
 `;
 
-const ProductionName = styled.div`
-  font-size: 1.4rem;
-  font-weight: bold;
-  margin: 0 0 1rem;
-  word-break: break-word;
+const ListWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 0 0 2rem;
 `;
 
-const ProductionId = styled.div`
-  font-size: 2rem;
-  color: #9e9e9e;
-`;
-
-export const ProductionsList = () => {
+export const ProductionsListContainer = () => {
   const [{ reloadProductionList }] = useGlobalState();
 
   const { productions, doInitialLoad, error, setIntervalLoad } =
@@ -63,23 +46,18 @@ export const ProductionsList = () => {
 
   return (
     <>
-      <LoaderDots
-        className={showRefreshing ? "active" : "in-active"}
-        text="refreshing"
-      />
+      <LoaderWrapper>
+        <LoaderDots
+          className={showRefreshing ? "active" : "in-active"}
+          text="refreshing"
+        />
+      </LoaderWrapper>
       <HeaderContainer>
         <DisplayContainerHeader>Production List</DisplayContainerHeader>
       </HeaderContainer>
-      <ProductionListContainer>
-        {error && <LocalError error={error} />}
-        {!error &&
-          productions.map((p) => (
-            <ProductionItem key={p.productionId}>
-              <ProductionName>{p.name}</ProductionName>
-              <ProductionId>{p.productionId}</ProductionId>
-            </ProductionItem>
-          ))}
-      </ProductionListContainer>
+      <ListWrapper>
+        <ProductionsList productions={productions} error={error} />
+      </ListWrapper>
       {!!productions.length && <ManageProductionButton />}
     </>
   );

--- a/src/components/landing-page/use-fetch-production-list.ts
+++ b/src/components/landing-page/use-fetch-production-list.ts
@@ -5,6 +5,7 @@ import { TBasicProduction } from "../production-line/types.ts";
 
 export const useFetchProductionList = () => {
   const [productions, setProductions] = useState<TBasicProduction[]>([]);
+  const [allProductions, setAllProductions] = useState<TBasicProduction[]>([]);
   const [doInitialLoad, setDoInitialLoad] = useState(true);
   const [intervalLoad, setIntervalLoad] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
@@ -21,9 +22,11 @@ export const useFetchProductionList = () => {
 
           setProductions(
             result
-              // pick last 10 items and display newest first
+              // pick last 10 items
               .slice(0, 10)
           );
+
+          setAllProductions(result);
 
           dispatch({
             type: "PRODUCTION_LIST_FETCHED",
@@ -48,6 +51,7 @@ export const useFetchProductionList = () => {
   }, [dispatch, intervalLoad, reloadProductionList, doInitialLoad]);
 
   return {
+    allProductions,
     productions,
     doInitialLoad,
     error,

--- a/src/components/landing-page/use-refresh-animation.ts
+++ b/src/components/landing-page/use-refresh-animation.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 type TUseRefreshAnimationOptions = {
-  reloadProductionList: boolean;
+  reloadProductionList?: boolean;
   doInitialLoad: boolean;
 };
 

--- a/src/components/manage-productions/manage-lines.tsx
+++ b/src/components/manage-productions/manage-lines.tsx
@@ -37,7 +37,7 @@ const Container = styled.div`
   max-width: 45rem;
   min-width: 35rem;
   padding: 2rem;
-  margin-right: 2rem;
+  margin: 0 2rem 2rem 0;
   border-radius: 1rem;
   border: 0.2rem solid #434343;
 `;

--- a/src/components/manage-productions/manage-productions.tsx
+++ b/src/components/manage-productions/manage-productions.tsx
@@ -5,6 +5,7 @@ import styled from "@emotion/styled";
 import { DisplayContainerHeader } from "../landing-page/display-container-header";
 import {
   DecorativeLabel,
+  PrimaryButton,
   StyledWarningMessage,
 } from "../landing-page/form-elements";
 import { useFetchProduction } from "../landing-page/use-fetch-production";
@@ -15,10 +16,20 @@ import { FormInputWithLoader } from "../landing-page/form-input-with-loader";
 import { RemoveProduction } from "./remove-production";
 import { ManageLines } from "./manage-lines";
 import { TProduction } from "../production-line/types";
+import { ProductionsList } from "../productions-list";
+import { useFetchProductionList } from "../landing-page/use-fetch-production-list";
 
 type FormValue = {
   productionId: string;
 };
+
+const ShowListBtn = styled(PrimaryButton)`
+  margin-bottom: 2rem;
+`;
+
+const FormInputWrapper = styled.div`
+  max-width: 45rem;
+`;
 
 const SubContainers = styled.div`
   width: 100%;
@@ -28,8 +39,13 @@ const SubContainers = styled.div`
 `;
 
 const Container = styled.form`
-  max-width: 45rem;
   padding: 1rem 2rem 0 2rem;
+`;
+
+const ListWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 `;
 
 const RemoveConfirmation = styled.div`
@@ -55,6 +71,8 @@ export const ManageProductions = () => {
   const [showDeleteDoneMessage, setShowDeleteDoneMessage] =
     useState<boolean>(false);
   const [verifyRemove, setVerifyRemove] = useState<boolean>(false);
+  const [showProductionsList, setShowProductionsList] =
+    useState<boolean>(false);
   const [delayOnGuideText, setDelayOnGuideText] = useState<boolean>(false);
   const [removeId, setRemoveId] = useState<null | number>(null);
   const [cachedProduction, setCachedProduction] = useState<null | TProduction>(
@@ -77,6 +95,8 @@ export const ManageProductions = () => {
     required: "Production ID is required",
     min: 1,
   });
+
+  const { productions, error } = useFetchProductionList();
 
   const {
     error: productionFetchError,
@@ -110,6 +130,7 @@ export const ManageProductions = () => {
     if (production) {
       setCachedProduction(production);
       setProductionIdToFetch(null);
+      setShowProductionsList(false);
     }
   }, [production]);
 
@@ -159,35 +180,61 @@ export const ManageProductions = () => {
         <NavigateToRootButton />
       </StyledBackBtnIcon>
       <DisplayContainerHeader>Manage Productions</DisplayContainerHeader>
-      <FormInputWithLoader
-        onChange={(ev) => {
-          onChange(ev);
-          const pid = parseInt(ev.target.value, 10);
-          const confirmedPid = Number.isNaN(pid) ? null : pid;
+      {cachedProduction && !showProductionsList && (
+        <ShowListBtn
+          type="button"
+          onClick={() => {
+            setShowProductionsList(true);
+          }}
+        >
+          Show Productions List
+        </ShowListBtn>
+      )}
+      {(!cachedProduction || showProductionsList) && (
+        <ListWrapper>
+          <ProductionsList
+            productions={productions}
+            error={error}
+            manageProduction={(v: string) => {
+              setProductionIdToFetch(parseInt(v, 10));
+              reset({
+                productionId: `${v}`,
+              });
+              setShowProductionsList(false);
+            }}
+          />
+        </ListWrapper>
+      )}
+      <FormInputWrapper>
+        <FormInputWithLoader
+          onChange={(ev) => {
+            onChange(ev);
+            const pid = parseInt(ev.target.value, 10);
+            const confirmedPid = Number.isNaN(pid) ? null : pid;
 
-          setProductionIdToFetch(confirmedPid);
-          setShowDeleteDoneMessage(false);
-        }}
-        label="Production ID"
-        placeholder="Production ID"
-        name={name}
-        inputRef={ref}
-        onBlur={onBlur}
-        type="number"
-        loading={fetchLoader}
-      />
-      {productionFetchError && (
-        <FetchErrorMessage>
-          The production ID could not be fetched. {productionFetchError.name}{" "}
-          {productionFetchError.message}.
-        </FetchErrorMessage>
-      )}
-      {productionDeleteError && (
-        <FetchErrorMessage>
-          The production ID could not be deleted. {productionDeleteError.name}{" "}
-          {productionDeleteError.message}.
-        </FetchErrorMessage>
-      )}
+            setProductionIdToFetch(confirmedPid);
+            setShowDeleteDoneMessage(false);
+          }}
+          label="Production ID"
+          placeholder="Production ID"
+          name={name}
+          inputRef={ref}
+          onBlur={onBlur}
+          type="number"
+          loading={fetchLoader}
+        />
+        {delayOnGuideText && (
+          <StyledWarningMessage>
+            Please enter a production id
+          </StyledWarningMessage>
+        )}
+        {productionFetchError && (
+          <FetchErrorMessage>
+            The production ID could not be fetched. {productionFetchError.name}{" "}
+            {productionFetchError.message}.
+          </FetchErrorMessage>
+        )}
+      </FormInputWrapper>
       <ErrorMessage
         errors={errors}
         name="productionId"
@@ -211,15 +258,20 @@ export const ManageProductions = () => {
               reset={() => {
                 setVerifyRemove(false);
                 setRemoveId(null);
+                setCachedProduction(null);
+                reset({
+                  productionId: "",
+                });
               }}
             />
           </SubContainers>
         </>
       )}
-      {delayOnGuideText && (
-        <StyledWarningMessage>
-          Please enter a production id
-        </StyledWarningMessage>
+      {productionDeleteError && (
+        <FetchErrorMessage>
+          The production ID could not be deleted. {productionDeleteError.name}{" "}
+          {productionDeleteError.message}.
+        </FetchErrorMessage>
       )}
       {showDeleteDoneMessage && (
         <RemoveConfirmation>

--- a/src/components/manage-productions/remove-production.tsx
+++ b/src/components/manage-productions/remove-production.tsx
@@ -7,6 +7,7 @@ const Container = styled.div`
   max-width: 45rem;
   min-width: 35rem;
   padding: 2rem;
+  margin: 0 2rem 2rem 0;
   border-radius: 1rem;
   border: 0.2rem solid #434343;
 `;

--- a/src/components/productions-list.tsx
+++ b/src/components/productions-list.tsx
@@ -1,0 +1,60 @@
+import styled from "@emotion/styled";
+import { TBasicProduction } from "./production-line/types.ts";
+import { LocalError } from "./error.tsx";
+
+const ProductionItem = styled.button`
+  text-align: start;
+  background-color: transparent;
+  flex: 1 0 calc(25% - 2rem);
+  justify-content: start;
+  min-width: 20rem;
+  border: 1px solid #424242;
+  border-radius: 0.5rem;
+  padding: 2rem;
+  margin: 0 2rem 2rem 0;
+`;
+
+const ProductionName = styled.div`
+  font-size: 1.4rem;
+  font-weight: bold;
+  margin: 0 0 1rem;
+  word-break: break-word;
+`;
+
+const ProductionId = styled.div`
+  font-size: 2rem;
+  color: #9e9e9e;
+`;
+
+type TProductionsList = {
+  productions: TBasicProduction[];
+  error: Error | null;
+  manageProduction?: (v: string) => void;
+};
+
+export const ProductionsList = ({
+  productions,
+  error,
+  manageProduction,
+}: TProductionsList) => {
+  return (
+    <>
+      {error && <LocalError error={error} />}
+      {!error &&
+        productions.map((p) => (
+          <ProductionItem
+            key={p.productionId}
+            type="button"
+            onClick={() =>
+              manageProduction
+                ? manageProduction(p.productionId)
+                : console.log("")
+            }
+          >
+            <ProductionName>{p.name}</ProductionName>
+            <ProductionId>{p.productionId}</ProductionId>
+          </ProductionItem>
+        ))}
+    </>
+  );
+};

--- a/src/global-state/global-state-actions.ts
+++ b/src/global-state/global-state-actions.ts
@@ -21,7 +21,7 @@ export type TDominantSpeaker = {
 };
 
 export type TProductionCreated = {
-  type: "PRODUCTION_CREATED";
+  type: "PRODUCTION_UPDATED";
 };
 
 export type TProductionListFetched = {

--- a/src/global-state/global-state-reducer.ts
+++ b/src/global-state/global-state-reducer.ts
@@ -25,7 +25,7 @@ const globalReducer: Reducer<TGlobalState, TGlobalStateAction> = (
         ...state,
         error: action.payload,
       };
-    case "PRODUCTION_CREATED":
+    case "PRODUCTION_UPDATED":
       return {
         ...state,
         reloadProductionList: true,


### PR DESCRIPTION
## Updated Layout!


# First view:
Now all productions are displayed.
<img width="1792" alt="Screenshot 2024-07-09 at 08 14 00" src="https://github.com/Eyevinn/intercom-frontend/assets/109201562/a7e9a3fa-9322-4877-991b-c5f7cf3ccb2d">


# When selected a production:
Either by clicking on one off the list-items or by writing a fetchable production-id
<img width="1174" alt="Screenshot 2024-07-09 at 08 14 15" src="https://github.com/Eyevinn/intercom-frontend/assets/109201562/9675933d-3b16-4b84-aab5-f12592724676">

