### PR TITLE
fix: list on launch page doesnt display last items

### DIFF
--- a/src/components/landing-page/use-fetch-production-list.ts
+++ b/src/components/landing-page/use-fetch-production-list.ts
@@ -21,8 +21,14 @@ export const useFetchProductionList = () => {
 
           setProductions(
             result
-              // pick laste 10 items
-              .slice(-10)
+
+              // Make sure list is correctly sorted
+              .sort(
+                (a, b) =>
+                  parseInt(b.productionId, 10) - parseInt(a.productionId, 10)
+              )
+              // pick last 10 items and display newest first
+              .slice(0, 10)
           );
 
           dispatch({

--- a/src/components/landing-page/use-fetch-production-list.ts
+++ b/src/components/landing-page/use-fetch-production-list.ts
@@ -21,12 +21,6 @@ export const useFetchProductionList = () => {
 
           setProductions(
             result
-
-              // Make sure list is correctly sorted
-              .sort(
-                (a, b) =>
-                  parseInt(b.productionId, 10) - parseInt(a.productionId, 10)
-              )
               // pick last 10 items and display newest first
               .slice(0, 10)
           );


### PR DESCRIPTION
List is currently displayed wrong and only returns the 10 oldest productions. This is probably due to a re-arrange of the results in handleFetchRequest or somewhere else along the fetch-line.

Added a sorting that guarantees that the sorting always will arrange the production-id from highest to lowest, to make sure that the last added productions will be displayed.