### PR TITLE
feat: added copy production-urls to clipboard

### DIFF
--- a/src/components/landing-page/create-production.tsx
+++ b/src/components/landing-page/create-production.tsx
@@ -122,25 +122,27 @@ export const CreateProduction = () => {
     }
   }, [createdProductionId, dispatch, reset]);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleCopyProdUrlsToClipboard = (input: any) => {
+  useEffect(() => {
+    let timeout: number | null = null;
+    if (copiedUrl) {
+      timeout = window.setTimeout(() => {
+        setCopiedUrl(false);
+      }, 1500);
+    }
+    return () => {
+      if (timeout !== null) {
+        window.clearTimeout(timeout);
+      }
+    };
+  }, [copiedUrl]);
+
+  const handleCopyProdUrlsToClipboard = (input: string[]) => {
     if (input !== null) {
       navigator.clipboard
-        .writeText(input)
+        .writeText(input.join("\n"))
         .then(() => {
-          let timeout: number | null = null;
           setCopiedUrl(true);
           console.log("Text copied to clipboard");
-
-          timeout = window.setTimeout(() => {
-            setCopiedUrl(false);
-          }, 1500);
-
-          return () => {
-            if (timeout !== null) {
-              window.clearTimeout(timeout);
-            }
-          };
         })
         .catch((err) => {
           console.error("Failed to copy text: ", err);
@@ -229,12 +231,12 @@ export const CreateProduction = () => {
           </PrimaryButton>
         </ButtonWrapper>
       </FlexContainer>
-      {createdProductionId !== null && production && (
+      {createdProductionId !== null && (
         <>
           <ProductionConfirmation>
             The production ID is: {createdProductionId.toString()}
           </ProductionConfirmation>
-          {!productionFetchError && (
+          {!productionFetchError && production && (
             <CopyToClipboardWrapper>
               <PrimaryButton
                 type="button"

--- a/src/components/landing-page/create-production.tsx
+++ b/src/components/landing-page/create-production.tsx
@@ -134,7 +134,7 @@ export const CreateProduction = () => {
 
           timeout = window.setTimeout(() => {
             setCopiedUrl(false);
-          }, 11500);
+          }, 1500);
 
           return () => {
             if (timeout !== null) {


### PR DESCRIPTION
Added a button to copy urls to clipboard when a production has successfully been created. The copied information looks like this, because the person copying them won't primarily be using the url:s only distributing them:

 test-1: http://<`${window.location.origin}`>/production/139/line/1, test-2: http://<`${window.location.origin}`>/production/139/line/2, test-3: http://<`${window.location.origin}`>/production/139/line/3
 
 ## When creation har been confirmed

<img width="789" alt="Screenshot 2024-07-12 at 14 41 03" src="https://github.com/user-attachments/assets/0b38bccb-6ac7-4512-8df4-14e86acd4a0d">

 ## When copy has been clicked, reset in 1500 ms

<img width="698" alt="Screenshot 2024-07-12 at 14 41 14" src="https://github.com/user-attachments/assets/26c0c61c-2ae8-4344-bb45-f181ec9adf0e">

 ## Fetch-error

<img width="790" alt="Screenshot 2024-07-12 at 14 49 29" src="https://github.com/user-attachments/assets/4d60811d-d263-474f-9eed-2b80861413b8">
