### PR TITLE
fix: line being added to all prods

### DIFF
--- a/src/components/manage-productions/manage-lines.tsx
+++ b/src/components/manage-productions/manage-lines.tsx
@@ -155,6 +155,7 @@ export const ManageLines = ({
       setRemoveId(null);
       setVerifyRemove(null);
       setRemoveActive(false);
+      setUpdateLines(null);
       setProductionIdToFetch(parseInt(production.productionId, 10));
     }
   }, [


### PR DESCRIPTION
Ran into a problem where in some cases when adding a line to a production, that line would be added to several productions. The problem seems to stem from the updatedLines-state not being cleared after a successful create or delete.
