### PR TITLE
Fix/modal and button fixes on callpage

### DIFF
--- a/src/components/calls-page/calls-page.tsx
+++ b/src/components/calls-page/calls-page.tsx
@@ -74,21 +74,29 @@ export const CallsPage = () => {
   const runExitAllCalls = async () => {
     setProductionId(null);
     navigate("/");
-    Object.entries(calls).forEach(([callId]) => {
-      if (callId) {
-        dispatch({
-          type: "REMOVE_CALL",
-          payload: { id: callId },
-        });
-      }
-    });
+    if (!isEmpty) {
+      Object.entries(calls).forEach(([callId]) => {
+        if (callId) {
+          dispatch({
+            type: "REMOVE_CALL",
+            payload: { id: callId },
+          });
+        }
+      });
+    }
   };
 
   return (
     <Container>
       <ButtonWrapper>
         <NavigateToRootButton
-          resetOnExitRequest={() => setConfirmExitModalOpen(true)}
+          resetOnExitRequest={() => {
+            if (isEmpty) {
+              runExitAllCalls();
+            } else {
+              setConfirmExitModalOpen(true);
+            }
+          }}
         />
         {confirmExitModalOpen && (
           <Modal onClose={() => setConfirmExitModalOpen(false)}>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -35,23 +35,28 @@ export const Header: FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { playExitSound } = useAudioCue();
+  const isEmpty = Object.values(calls).length === 0;
 
   const runExitAllCalls = () => {
     setConfirmExitModalOpen(false);
     navigate("/");
     playExitSound();
-    Object.entries(calls).forEach(([callId]) => {
-      if (callId) {
-        dispatch({
-          type: "REMOVE_CALL",
-          payload: { id: callId },
-        });
-      }
-    });
+    if (!isEmpty) {
+      Object.entries(calls).forEach(([callId]) => {
+        if (callId) {
+          dispatch({
+            type: "REMOVE_CALL",
+            payload: { id: callId },
+          });
+        }
+      });
+    }
   };
 
   const returnToRoot = () => {
-    if (location.pathname.includes("/line")) {
+    if (location.pathname.includes("/line") && isEmpty) {
+      runExitAllCalls();
+    } else if (location.pathname.includes("/line")) {
       setConfirmExitModalOpen(true);
     } else {
       navigate("/");

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -194,6 +194,31 @@ export const ProductionLine = ({
     sessionId,
   } = callState;
 
+  const {
+    formState: { isValid, isDirty },
+    register,
+    handleSubmit,
+    watch,
+  } = useForm<FormValues>({
+    defaultValues: {
+      username: "",
+      productionId: paramProductionId || "",
+      lineId: paramLineId || undefined,
+    },
+    resetOptions: {
+      keepDirtyValues: true, // user-interacted input will be retained
+      keepErrors: true, // input errors will be retained with value update
+    },
+  });
+
+  // Watch all form values
+  const watchedValues = watch();
+  const audioInputTheSame =
+    joinProductionOptions?.audioinput === watchedValues.audioinput;
+  const audioOutputTheSame =
+    joinProductionOptions?.audiooutput === watchedValues.audiooutput;
+  const audioNotChanged = audioInputTheSame && audioOutputTheSame;
+
   const [inputAudioStream, resetAudioInput] = useAudioInput({
     audioInputId: joinProductionOptions?.audioinput ?? null,
     audioOutputId: joinProductionOptions?.audiooutput ?? null,
@@ -346,22 +371,6 @@ export const ProductionLine = ({
     dispatch,
   });
 
-  const {
-    formState: { isValid, isDirty },
-    register,
-    handleSubmit,
-  } = useForm<FormValues>({
-    defaultValues: {
-      username: "",
-      productionId: paramProductionId || "",
-      lineId: paramLineId || undefined,
-    },
-    resetOptions: {
-      keepDirtyValues: true, // user-interacted input will be retained
-      keepErrors: true, // input errors will be retained with value update
-    },
-  });
-
   const outputDevices = devices
     ? uniqBy(
         devices.filter((d) => d.kind === "audiooutput"),
@@ -383,10 +392,7 @@ export const ProductionLine = ({
 
   // Reset connection and re-connect to production-line
   const onSubmit: SubmitHandler<FormValues> = async (payload) => {
-    const unchangedPayload =
-      payload.audioinput === joinProductionOptions?.audioinput &&
-      payload.audiooutput === joinProductionOptions?.audiooutput;
-    if (joinProductionOptions && !unchangedPayload) {
+    if (joinProductionOptions && !audioNotChanged) {
       setConnectionActive(false);
       resetAudioInput();
       muteInput(true);
@@ -607,7 +613,7 @@ export const ProductionLine = ({
                   <ButtonWrapper>
                     <PrimaryButton
                       type="submit"
-                      disabled={!isValid || !isDirty}
+                      disabled={audioNotChanged || !isValid || !isDirty}
                       onClick={handleSubmit(onSubmit)}
                     >
                       Save

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -611,13 +611,13 @@ export const ProductionLine = ({
                     </StyledWarningMessage>
                   )}
                   <ButtonWrapper>
-                    <PrimaryButton
+                    <ActionButton
                       type="submit"
                       disabled={audioNotChanged || !isValid || !isDirty}
                       onClick={handleSubmit(onSubmit)}
                     >
                       Save
-                    </PrimaryButton>
+                    </ActionButton>
                     {!(isBrowserFirefox && !isMobile) && (
                       <ReloadDevicesButton
                         handleReloadDevices={() =>


### PR DESCRIPTION
#What does this do?

 - Unnecessary confirm-modal removed if user has routed on direct-link and not yet connected to call and then presses "home"-button or "return"-button.
 
 - If user is trying to change connected device and reselects the devices already connected to the call, the "save"-button will be disabled.