### PR TITLE
fix: show volume control on supported devices

### DIFF
--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -20,5 +20,5 @@ export const isValidBrowser = browser.satisfies({
 export const isBrowserFirefox = browserName.toLowerCase() === "firefox";
 
 export const isIpadOS = () => {
-  return navigator.maxTouchPoints && navigator.maxTouchPoints > 2;
+  return !!navigator.maxTouchPoints && navigator.maxTouchPoints > 2;
 };

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -19,6 +19,16 @@ export const isValidBrowser = browser.satisfies({
 
 export const isBrowserFirefox = browserName.toLowerCase() === "firefox";
 
-export const isIpadOS = () => {
-  return !!navigator.maxTouchPoints && navigator.maxTouchPoints > 2;
+// Helper function to detect iPad specifically
+export const isIpad = (): boolean => {
+  const ua = window.navigator.userAgent.toLowerCase();
+  const platform = window.navigator.platform.toLowerCase();
+  const maxTouchPoints = navigator.maxTouchPoints || 0;
+
+  // iPad detection logic
+  return (
+    platform.includes("ipad") ||
+    ua.includes("ipad") || // Older iPads
+    (maxTouchPoints > 1 && platform.includes("mac") && ua.includes("safari")) // iPadOS reporting as Mac
+  );
 };

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -25,10 +25,11 @@ export const isIpad = (): boolean => {
   const platform = window.navigator.platform.toLowerCase();
   const maxTouchPoints = navigator.maxTouchPoints || 0;
 
-  // iPad detection logic
-  return (
+  const result =
     platform.includes("ipad") ||
-    ua.includes("ipad") || // Older iPads
-    (maxTouchPoints > 1 && platform.includes("mac") && ua.includes("safari")) // iPadOS reporting as Mac
-  );
+    ua.includes("ipad") ||
+    (maxTouchPoints > 1 && platform.includes("mac") && ua.includes("safari"));
+
+  console.log("Inside isIpad: ", result); // Debug here
+  return result;
 };

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -1,8 +1,8 @@
 import Bowser from "bowser";
 
-const deviceInfo = Bowser.parse(window.navigator.userAgent);
-const browser = Bowser.getParser(window.navigator.userAgent);
-const browserName = browser.getBrowserName();
+export const deviceInfo = Bowser.parse(window.navigator.userAgent);
+export const browser = Bowser.getParser(window.navigator.userAgent);
+export const browserName = browser.getBrowserName();
 
 // platform type, can be either "desktop", "tablet" or "mobile"
 export const isMobile = deviceInfo.platform.type === "mobile";

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -4,8 +4,14 @@ const deviceInfo = Bowser.parse(window.navigator.userAgent);
 const browser = Bowser.getParser(window.navigator.userAgent);
 const browserName = browser.getBrowserName();
 
+const isIOS = (): boolean => {
+  const ua = window.navigator.userAgent.toLowerCase();
+  return /iphone|ipod|ipad/.test(ua);
+};
+
 // platform type, can be either "desktop", "tablet" or "mobile"
 export const isMobile = deviceInfo.platform.type === "mobile";
+export const isIOSMobile = isIOS() && isMobile;
 
 export const isValidBrowser = browser.satisfies({
   chrome: ">=115",
@@ -31,6 +37,6 @@ const detectIpad = (): boolean => {
   return result;
 };
 
-const isIpad = detectIpad();
+export const isIpad = detectIpad();
 
 export const isTablet = deviceInfo.platform.type === "tablet" || isIpad;

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -7,8 +7,6 @@ const browserName = browser.getBrowserName();
 // platform type, can be either "desktop", "tablet" or "mobile"
 export const isMobile = deviceInfo.platform.type === "mobile";
 
-export const isTablet = deviceInfo.platform.type === "tablet";
-
 export const isValidBrowser = browser.satisfies({
   chrome: ">=115",
   edge: ">=115",
@@ -19,7 +17,7 @@ export const isValidBrowser = browser.satisfies({
 
 export const isBrowserFirefox = browserName.toLowerCase() === "firefox";
 
-// Used because isTablet does not detect iPad as iPads have platform desktop and browser Safari
+// Used because iPads have platform as desktop and browser as Safari
 const detectIpad = (): boolean => {
   const ua = window.navigator.userAgent.toLowerCase();
   const platform = window.navigator.platform.toLowerCase();
@@ -33,5 +31,6 @@ const detectIpad = (): boolean => {
   return result;
 };
 
-export const isIpad = detectIpad();
-console.log(isIpad);
+const isIpad = detectIpad();
+
+export const isTablet = deviceInfo.platform.type === "tablet" || isIpad;

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -18,3 +18,7 @@ export const isValidBrowser = browser.satisfies({
 });
 
 export const isBrowserFirefox = browserName.toLowerCase() === "firefox";
+
+export const isIpadOS = () => {
+  return navigator.maxTouchPoints && navigator.maxTouchPoints > 2;
+};

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -7,6 +7,8 @@ const browserName = browser.getBrowserName();
 // platform type, can be either "desktop", "tablet" or "mobile"
 export const isMobile = deviceInfo.platform.type === "mobile";
 
+export const isTablet = deviceInfo.platform.type === "tablet";
+
 export const isValidBrowser = browser.satisfies({
   chrome: ">=115",
   edge: ">=115",

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -1,8 +1,8 @@
 import Bowser from "bowser";
 
-export const deviceInfo = Bowser.parse(window.navigator.userAgent);
-export const browser = Bowser.getParser(window.navigator.userAgent);
-export const browserName = browser.getBrowserName();
+const deviceInfo = Bowser.parse(window.navigator.userAgent);
+const browser = Bowser.getParser(window.navigator.userAgent);
+const browserName = browser.getBrowserName();
 
 // platform type, can be either "desktop", "tablet" or "mobile"
 export const isMobile = deviceInfo.platform.type === "mobile";
@@ -19,8 +19,8 @@ export const isValidBrowser = browser.satisfies({
 
 export const isBrowserFirefox = browserName.toLowerCase() === "firefox";
 
-// Helper function to detect iPad specifically
-export const isIpad = (): boolean => {
+// Used because isTablet does not detect iPad as iPads have platform desktop and browser Safari
+const detectIpad = (): boolean => {
   const ua = window.navigator.userAgent.toLowerCase();
   const platform = window.navigator.platform.toLowerCase();
   const maxTouchPoints = navigator.maxTouchPoints || 0;
@@ -30,6 +30,7 @@ export const isIpad = (): boolean => {
     ua.includes("ipad") ||
     (maxTouchPoints > 1 && platform.includes("mac") && ua.includes("safari"));
 
-  console.log("Inside isIpad: ", result); // Debug here
   return result;
 };
+
+export const isIpad = detectIpad();

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -34,3 +34,4 @@ const detectIpad = (): boolean => {
 };
 
 export const isIpad = detectIpad();
+console.log(isIpad);

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -27,7 +27,7 @@ import { Spinner } from "../loader/loader.tsx";
 import { DisplayContainerHeader } from "../landing-page/display-container-header.tsx";
 import { DisplayContainer, FlexContainer } from "../generic-components.ts";
 import { useDeviceLabels } from "./use-device-labels.ts";
-import { isBrowserFirefox, isMobile, isTablet, isIpad } from "../../bowser.ts";
+import { isBrowserFirefox, isMobile, isTablet } from "../../bowser.ts";
 import { useLineHotkeys, useSpeakerHotkeys } from "./use-line-hotkeys.ts";
 import { LongPressToTalkButton } from "./long-press-to-talk-button.tsx";
 import { useLinePolling } from "./use-line-polling.ts";
@@ -493,7 +493,7 @@ export const ProductionLine = ({
               }}
             >
               <DisplayContainerHeader>Controls</DisplayContainerHeader>
-              {!isMobile && !isTablet && !isIpad && (
+              {!isMobile && !isTablet && (
                 <VolumeSlider
                   value={value}
                   handleInputChange={handleInputChange}

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -233,6 +233,10 @@ export const ProductionLine = ({
       // eslint-disable-next-line no-param-reassign
       audioElement.volume = newValue;
     });
+
+    if (newValue > 0 && isOutputMuted) {
+      setIsOutputMuted(false);
+    }
   });
 
   const muteInput = useCallback(

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -27,7 +27,14 @@ import { Spinner } from "../loader/loader.tsx";
 import { DisplayContainerHeader } from "../landing-page/display-container-header.tsx";
 import { DisplayContainer, FlexContainer } from "../generic-components.ts";
 import { useDeviceLabels } from "./use-device-labels.ts";
-import { isBrowserFirefox, isMobile, isTablet } from "../../bowser.ts";
+import {
+  isBrowserFirefox,
+  isMobile,
+  isTablet,
+  deviceInfo,
+  browser,
+  browserName,
+} from "../../bowser.ts";
 import { useLineHotkeys, useSpeakerHotkeys } from "./use-line-hotkeys.ts";
 import { LongPressToTalkButton } from "./long-press-to-talk-button.tsx";
 import { useLinePolling } from "./use-line-polling.ts";
@@ -312,6 +319,9 @@ export const ProductionLine = ({
 
   useEffect(() => {
     console.log("IS TABLET: ", isTablet);
+    console.log("DEVICE INFO: ", deviceInfo);
+    console.log("BROWSER: ", browser);
+    console.log("BROWSER NAME: ", browserName);
   });
 
   useEffect(() => {

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -311,6 +311,10 @@ export const ProductionLine = ({
   );
 
   useEffect(() => {
+    console.log("IS TABLET: ", isTablet);
+  });
+
+  useEffect(() => {
     if (!fetchProductionError) return;
 
     dispatch({

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -263,13 +263,6 @@ export const ProductionLine = ({
 
   const { playEnterSound, playExitSound } = useAudioCue();
 
-  useEffect(() => {
-    console.log("IS MOBILE: ", isMobile);
-    console.log("IS TABLET: ", isTablet);
-    console.log("IS IOS MOBILE: ", isIOSMobile);
-    console.log("IS IPAD: ", isIpad);
-  });
-
   const exit = useCallback(() => {
     setConnectionActive(false);
     playExitSound();
@@ -291,10 +284,6 @@ export const ProductionLine = ({
     permission: true,
     refresh,
   });
-
-  useEffect(() => {
-    console.log("IS OUTPUT MUTED: ", isOutputMuted);
-  }, [isOutputMuted]);
 
   useEffect(() => {
     if (joinProductionOptions) {
@@ -529,7 +518,11 @@ export const ProductionLine = ({
                     disabled={value === 0}
                   >
                     <ButtonIcon>
-                      {isOutputMuted ? <SpeakerOff /> : <SpeakerOn />}
+                      {isOutputMuted || value === 0 ? (
+                        <SpeakerOff />
+                      ) : (
+                        <SpeakerOn />
+                      )}
                     </ButtonIcon>
                   </UserControlBtn>
                 </FlexButtonWrapper>

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -27,15 +27,7 @@ import { Spinner } from "../loader/loader.tsx";
 import { DisplayContainerHeader } from "../landing-page/display-container-header.tsx";
 import { DisplayContainer, FlexContainer } from "../generic-components.ts";
 import { useDeviceLabels } from "./use-device-labels.ts";
-import {
-  isBrowserFirefox,
-  isMobile,
-  isTablet,
-  deviceInfo,
-  browser,
-  browserName,
-  isIpad,
-} from "../../bowser.ts";
+import { isBrowserFirefox, isMobile, isTablet, isIpad } from "../../bowser.ts";
 import { useLineHotkeys, useSpeakerHotkeys } from "./use-line-hotkeys.ts";
 import { LongPressToTalkButton } from "./long-press-to-talk-button.tsx";
 import { useLinePolling } from "./use-line-polling.ts";
@@ -319,12 +311,10 @@ export const ProductionLine = ({
   );
 
   useEffect(() => {
-    console.log("IS TABLET: ", isTablet);
-    console.log("DEVICE INFO: ", deviceInfo);
-    console.log("BROWSER: ", browser);
-    console.log("BROWSER NAME: ", browserName);
-    console.log("IS IPAD: ", isIpad());
-  });
+    console.log("Executing useEffect");
+    const ipadCheck = isIpad();
+    console.log("IS IPAD 2: ", ipadCheck);
+  }, []);
 
   useEffect(() => {
     if (!fetchProductionError) return;

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -311,12 +311,6 @@ export const ProductionLine = ({
   );
 
   useEffect(() => {
-    console.log("Executing useEffect");
-    const ipadCheck = isIpad();
-    console.log("IS IPAD 2: ", ipadCheck);
-  }, []);
-
-  useEffect(() => {
     if (!fetchProductionError) return;
 
     dispatch({
@@ -499,7 +493,7 @@ export const ProductionLine = ({
               }}
             >
               <DisplayContainerHeader>Controls</DisplayContainerHeader>
-              {!isMobile && !isTablet && (
+              {!isMobile && !isTablet && !isIpad && (
                 <VolumeSlider
                   value={value}
                   handleInputChange={handleInputChange}

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -286,10 +286,12 @@ export const ProductionLine = ({
   useEffect(() => {
     if (value === 0) {
       setIsOutputMuted(true);
-    } else {
-      setIsOutputMuted(false);
     }
   }, [value]);
+
+  useEffect(() => {
+    console.log("IS OUTPUT MUTED: ", isOutputMuted);
+  }, [isOutputMuted]);
 
   useEffect(() => {
     if (joinProductionOptions) {

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -213,6 +213,15 @@ export const ProductionLine = ({
       // eslint-disable-next-line no-param-reassign
       audioElement.volume = newValue;
     });
+
+    if (newValue > 0 && isOutputMuted) {
+      // Unmute the speaker if the slider is moved while muted.
+      setIsOutputMuted(false);
+      audioElements?.forEach((audioElement) => {
+        // eslint-disable-next-line no-param-reassign
+        audioElement.muted = false;
+      });
+    }
   };
 
   useHotkeys(savedHotkeys.increaseVolumeHotkey || "u", () => {
@@ -282,12 +291,6 @@ export const ProductionLine = ({
     permission: true,
     refresh,
   });
-
-  useEffect(() => {
-    if (value === 0) {
-      setIsOutputMuted(true);
-    }
-  }, [value]);
 
   useEffect(() => {
     console.log("IS OUTPUT MUTED: ", isOutputMuted);

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -27,7 +27,7 @@ import { Spinner } from "../loader/loader.tsx";
 import { DisplayContainerHeader } from "../landing-page/display-container-header.tsx";
 import { DisplayContainer, FlexContainer } from "../generic-components.ts";
 import { useDeviceLabels } from "./use-device-labels.ts";
-import { isBrowserFirefox, isMobile } from "../../bowser.ts";
+import { isBrowserFirefox, isMobile, isTablet } from "../../bowser.ts";
 import { useLineHotkeys, useSpeakerHotkeys } from "./use-line-hotkeys.ts";
 import { LongPressToTalkButton } from "./long-press-to-talk-button.tsx";
 import { useLinePolling } from "./use-line-polling.ts";
@@ -493,7 +493,7 @@ export const ProductionLine = ({
               }}
             >
               <DisplayContainerHeader>Controls</DisplayContainerHeader>
-              {!isMobile && (
+              {!isMobile && !isTablet && (
                 <VolumeSlider
                   value={value}
                   handleInputChange={handleInputChange}

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -215,7 +215,6 @@ export const ProductionLine = ({
     });
 
     if (newValue > 0 && isOutputMuted) {
-      // Unmute the speaker if the slider is moved while muted.
       setIsOutputMuted(false);
       audioElements?.forEach((audioElement) => {
         // eslint-disable-next-line no-param-reassign

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -34,6 +34,7 @@ import {
   deviceInfo,
   browser,
   browserName,
+  isIpadOS,
 } from "../../bowser.ts";
 import { useLineHotkeys, useSpeakerHotkeys } from "./use-line-hotkeys.ts";
 import { LongPressToTalkButton } from "./long-press-to-talk-button.tsx";
@@ -322,6 +323,7 @@ export const ProductionLine = ({
     console.log("DEVICE INFO: ", deviceInfo);
     console.log("BROWSER: ", browser);
     console.log("BROWSER NAME: ", browserName);
+    console.log("IS IPAD OS: ", isIpadOS);
   });
 
   useEffect(() => {

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -27,7 +27,13 @@ import { Spinner } from "../loader/loader.tsx";
 import { DisplayContainerHeader } from "../landing-page/display-container-header.tsx";
 import { DisplayContainer, FlexContainer } from "../generic-components.ts";
 import { useDeviceLabels } from "./use-device-labels.ts";
-import { isBrowserFirefox, isMobile, isTablet } from "../../bowser.ts";
+import {
+  isBrowserFirefox,
+  isMobile,
+  isIOSMobile,
+  isIpad,
+  isTablet,
+} from "../../bowser.ts";
 import { useLineHotkeys, useSpeakerHotkeys } from "./use-line-hotkeys.ts";
 import { LongPressToTalkButton } from "./long-press-to-talk-button.tsx";
 import { useLinePolling } from "./use-line-polling.ts";
@@ -243,6 +249,13 @@ export const ProductionLine = ({
   );
 
   const { playEnterSound, playExitSound } = useAudioCue();
+
+  useEffect(() => {
+    console.log("IS MOBILE: ", isMobile);
+    console.log("IS TABLET: ", isTablet);
+    console.log("IS IOS MOBILE: ", isIOSMobile);
+    console.log("IS IPAD: ", isIpad);
+  });
 
   const exit = useCallback(() => {
     setConnectionActive(false);
@@ -493,7 +506,7 @@ export const ProductionLine = ({
               }}
             >
               <DisplayContainerHeader>Controls</DisplayContainerHeader>
-              {!isMobile && !isTablet && (
+              {!isIOSMobile && !isIpad && (
                 <VolumeSlider
                   value={value}
                   handleInputChange={handleInputChange}
@@ -617,7 +630,8 @@ export const ProductionLine = ({
 
               {inputAudioStream &&
                 inputAudioStream !== "no-device" &&
-                !isMobile && (
+                !isMobile &&
+                !isTablet && (
                   <>
                     <HotkeyDiv>
                       <strong>Hotkeys</strong>

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -323,7 +323,7 @@ export const ProductionLine = ({
     console.log("DEVICE INFO: ", deviceInfo);
     console.log("BROWSER: ", browser);
     console.log("BROWSER NAME: ", browserName);
-    console.log("IS IPAD: ", isIpad);
+    console.log("IS IPAD: ", isIpad());
   });
 
   useEffect(() => {

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -34,7 +34,7 @@ import {
   deviceInfo,
   browser,
   browserName,
-  isIpadOS,
+  isIpad,
 } from "../../bowser.ts";
 import { useLineHotkeys, useSpeakerHotkeys } from "./use-line-hotkeys.ts";
 import { LongPressToTalkButton } from "./long-press-to-talk-button.tsx";
@@ -323,7 +323,7 @@ export const ProductionLine = ({
     console.log("DEVICE INFO: ", deviceInfo);
     console.log("BROWSER: ", browser);
     console.log("BROWSER NAME: ", browserName);
-    console.log("IS IPAD OS: ", isIpadOS);
+    console.log("IS IPAD: ", isIpad);
   });
 
   useEffect(() => {


### PR DESCRIPTION
Volume control is not supported on iOS mobile and iPhone, so this PR makes sure those features are disabled for those platform. Volume control on Android devices are supported so that is allowed. 

Hotkeys should not show on tablet but they did so I added a check for that as well.

I also noticed some undesired behavior with the volume slider: If you muted the speaker with the button, and then moved the slider, the button made it look like the speaker wasn't muted - but it was. Now I made it so that if the user mutes the speaker with the button, and then moves the slider - the speaker is unmuted.