### PR TITLE
Feat/global hotkeys

### DIFF
--- a/src/assets/icons/icon.tsx
+++ b/src/assets/icons/icon.tsx
@@ -22,6 +22,8 @@ import Person from "./person.svg?react";
 import Users from "./users.svg?react";
 import Add from "./add.svg?react";
 import Edit from "./edit.svg?react";
+import MegaphoneOff from "./campaign_off.svg?react";
+import MegaphoneOn from "./campaign_on.svg?react";
 
 export const MicMuted = () => <MicMute />;
 
@@ -70,3 +72,7 @@ export const UsersIcon = () => <Users />;
 export const AddIcon = () => <Add />;
 
 export const EditIcon = () => <Edit />;
+
+export const MegaphoneOffIcon = () => <MegaphoneOff />;
+
+export const MegaphoneOnIcon = () => <MegaphoneOn />;

--- a/src/components/calls-page/calls-page.tsx
+++ b/src/components/calls-page/calls-page.tsx
@@ -52,6 +52,8 @@ const ButtonWrapper = styled.div`
 `;
 
 const MuteAllCallsBtn = styled(PrimaryButton)`
+  background: rgba(50, 56, 59, 1);
+  border: 0.2rem solid #6d6d6d;
   padding: 0.5rem;
   margin: 0 0 0 1rem;
   width: 4rem;

--- a/src/components/calls-page/calls-page.tsx
+++ b/src/components/calls-page/calls-page.tsx
@@ -4,12 +4,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useGlobalState } from "../../global-state/context-provider";
 import { JoinProduction } from "../landing-page/join-production";
 import { ProductionLine } from "../production-line/production-line";
-import { SecondaryButton } from "../landing-page/form-elements";
+import { PrimaryButton, SecondaryButton } from "../landing-page/form-elements";
 import { NavigateToRootButton } from "../navigate-to-root-button/navigate-to-root-button";
 import { DisplayContainerHeader } from "../landing-page/display-container-header";
 import { Modal } from "../modal/modal";
 import { VerifyDecision } from "../verify-decision/verify-decision";
 import { ModalConfirmationText } from "../modal/modal-confirmation-text";
+import { MegaphoneOffIcon, MegaphoneOnIcon } from "../../assets/icons/icon";
+import { useGlobalHotkeys } from "../production-line/use-line-hotkeys";
 
 const Container = styled.div`
   display: flex;
@@ -42,16 +44,26 @@ const AddCallContainer = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
+  display: flex;
   margin: 0 1rem 1rem 0;
   :last-of-type {
     margin: 0 0 4rem;
   }
 `;
 
+const MuteAllCallsBtn = styled(PrimaryButton)`
+  padding: 0.5rem;
+  margin: 0 0 0 1rem;
+  width: 4rem;
+  height: 4rem;
+`;
+
 export const CallsPage = () => {
   const [productionId, setProductionId] = useState<string | null>(null);
   const [addCallActive, setAddCallActive] = useState(false);
   const [confirmExitModalOpen, setConfirmExitModalOpen] = useState(false);
+  const [isMasterInputMuted, setIsMasterInputMuted] = useState(true);
+  const [customGlobalMute, setCustomGlobalMute] = useState("p");
   const [{ calls, selectedProductionId }, dispatch] = useGlobalState();
   const { productionId: paramProductionId, lineId: paramLineId } = useParams();
   const navigate = useNavigate();
@@ -66,10 +78,29 @@ export const CallsPage = () => {
   }, [selectedProductionId]);
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    Object.entries(calls).forEach(([_, callState]) => {
+      if (
+        callState.hotkeys?.globalMuteHotkey &&
+        callState.hotkeys.globalMuteHotkey !== customGlobalMute
+      ) {
+        setCustomGlobalMute(callState.hotkeys.globalMuteHotkey);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [calls]);
+
+  useEffect(() => {
     if (isEmpty && !paramProductionId && !paramLineId) {
       navigate("/");
     }
   }, [isEmpty, paramProductionId, paramLineId, navigate]);
+
+  useGlobalHotkeys({
+    muteInput: setIsMasterInputMuted,
+    isInputMuted: isMasterInputMuted,
+    customKey: customGlobalMute || "p",
+  });
 
   const runExitAllCalls = async () => {
     setProductionId(null);
@@ -102,6 +133,14 @@ export const CallsPage = () => {
             />
           </Modal>
         )}
+        {!isEmpty && (
+          <MuteAllCallsBtn
+            type="button"
+            onClick={() => setIsMasterInputMuted(!isMasterInputMuted)}
+          >
+            {isMasterInputMuted ? <MegaphoneOffIcon /> : <MegaphoneOnIcon />}
+          </MuteAllCallsBtn>
+        )}
       </ButtonWrapper>
       <CallsContainer>
         {Object.entries(calls).map(
@@ -113,6 +152,8 @@ export const CallsPage = () => {
                   id={callId}
                   callState={callState}
                   isSingleCall={isSingleCall}
+                  customGlobalMute={customGlobalMute}
+                  masterInputMute={isMasterInputMuted}
                 />
               </CallContainer>
             )
@@ -129,6 +170,7 @@ export const CallsPage = () => {
             </ButtonWrapper>
             {addCallActive && productionId && (
               <JoinProduction
+                customGlobalMute={customGlobalMute}
                 addAdditionalCallId={productionId}
                 closeAddCallView={() => setAddCallActive(false)}
               />
@@ -142,6 +184,7 @@ export const CallsPage = () => {
                 preSelectedProductionId: paramProductionId,
                 preSelectedLineId: paramLineId,
               }}
+              customGlobalMute={customGlobalMute}
             />
           </CallContainer>
         )}

--- a/src/components/landing-page/form-elements.tsx
+++ b/src/components/landing-page/form-elements.tsx
@@ -76,6 +76,11 @@ export const StyledWarningMessage = styled.div`
   border: 1px solid #ebca6a;
   display: flex;
   align-items: center;
+
+  &.error-message {
+    background: #f96c6c;
+    border: 1px solid #f96c6c;
+  }
 `;
 
 export const ActionButton = styled.button`

--- a/src/components/landing-page/join-production.tsx
+++ b/src/components/landing-page/join-production.tsx
@@ -49,12 +49,14 @@ type TProps = {
     preSelectedProductionId: string;
     preSelectedLineId: string;
   };
+  customGlobalMute: string;
   addAdditionalCallId?: string;
   closeAddCallView?: () => void;
 };
 
 export const JoinProduction = ({
   preSelected,
+  customGlobalMute,
   addAdditionalCallId,
   closeAddCallView,
 }: TProps) => {
@@ -179,6 +181,14 @@ export const JoinProduction = ({
           connectionState: null,
           audioElements: null,
           sessionId: null,
+          hotkeys: {
+            muteHotkey: "m",
+            speakerHotkey: "n",
+            pushToTalkHotkey: "t",
+            increaseVolumeHotkey: "u",
+            decreaseVolumeHotkey: "d",
+            globalMuteHotkey: customGlobalMute,
+          },
         },
       },
     });

--- a/src/components/navigate-to-root-button/navigate-to-root-button.tsx
+++ b/src/components/navigate-to-root-button/navigate-to-root-button.tsx
@@ -9,6 +9,7 @@ const StyledBackBtn = styled.div`
   padding: 0;
   margin: 0;
   width: 4rem;
+  height: 4rem;
 `;
 
 export const NavigateToRootButton = ({

--- a/src/components/production-line/hotkeys-component.tsx
+++ b/src/components/production-line/hotkeys-component.tsx
@@ -1,0 +1,95 @@
+import styled from "@emotion/styled";
+import { useState } from "react";
+import { SettingsModal } from "./settings-modal";
+import { SettingsIcon } from "../../assets/icons/icon";
+import { Hotkeys, TLine } from "./types";
+
+const TempDiv = styled.div`
+  padding: 0 0 2rem 0;
+`;
+
+const HotkeyDiv = styled.div`
+  padding: 0 0 2rem 0;
+  flex-direction: row;
+  display: flex;
+  align-items: center;
+`;
+
+const SettingsBtn = styled.div`
+  padding: 0;
+  margin-left: 1.5rem;
+  width: 3rem;
+  cursor: pointer;
+  color: white;
+  background: transparent;
+`;
+
+type HotkeysComponentProps = {
+  callId: string;
+  savedHotkeys: Hotkeys;
+  customGlobalMute: string;
+  line: TLine | null;
+};
+
+export const HotkeysComponent = ({
+  callId,
+  savedHotkeys,
+  customGlobalMute,
+  line,
+}: HotkeysComponentProps) => {
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+
+  const handleSettingsClick = () => {
+    setIsSettingsModalOpen(!isSettingsModalOpen);
+  };
+
+  return (
+    <>
+      <HotkeyDiv>
+        <strong>Hotkeys</strong>
+        <SettingsBtn onClick={handleSettingsClick}>
+          <SettingsIcon />
+        </SettingsBtn>
+      </HotkeyDiv>
+      <TempDiv>
+        <strong>{(savedHotkeys?.muteHotkey || "").toUpperCase()}: </strong>
+        Toggle Input Mute
+      </TempDiv>
+      <TempDiv>
+        <strong>{(savedHotkeys?.speakerHotkey || "").toUpperCase()}: </strong>
+        Toggle Output Mute
+      </TempDiv>
+      <TempDiv>
+        <strong>
+          {(savedHotkeys?.pushToTalkHotkey || "").toUpperCase()}:{" "}
+        </strong>
+        Push to Talk
+      </TempDiv>
+      <TempDiv>
+        <strong>{savedHotkeys?.increaseVolumeHotkey.toUpperCase()}: </strong>
+        Increase Volume
+      </TempDiv>
+      <TempDiv>
+        <strong>{savedHotkeys?.decreaseVolumeHotkey.toUpperCase()}: </strong>
+        Decrease Volume
+      </TempDiv>
+      <TempDiv>
+        <strong>
+          {(savedHotkeys?.globalMuteHotkey || "").toUpperCase()}:{" "}
+        </strong>
+        Toggle Mute All Inputs
+      </TempDiv>
+      {isSettingsModalOpen && (
+        <SettingsModal
+          isOpen={isSettingsModalOpen}
+          callId={callId}
+          savedHotkeys={savedHotkeys}
+          customGlobalMute={customGlobalMute}
+          lineName={line?.name}
+          onSave={() => setIsSettingsModalOpen(false)}
+          onClose={handleSettingsClick}
+        />
+      )}
+    </>
+  );
+};

--- a/src/components/production-line/long-press-to-talk-button.tsx
+++ b/src/components/production-line/long-press-to-talk-button.tsx
@@ -90,7 +90,7 @@ export const LongPressToTalkButton = ({
           width: "100%",
         }}
       >
-        Press to Talk
+        Push to Talk
       </span>
     </Button>
   );

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -11,7 +11,6 @@ import {
   MicUnmuted,
   SpeakerOff,
   SpeakerOn,
-  SettingsIcon,
 } from "../../assets/icons/icon.tsx";
 import {
   ActionButton,
@@ -37,7 +36,6 @@ import { useCheckBadLineData } from "./use-check-bad-line-data.ts";
 import { useAudioCue } from "./use-audio-cue.ts";
 import { DisplayWarning } from "../display-box.tsx";
 import { TJoinProductionOptions } from "./types.ts";
-import { SettingsModal, Hotkeys } from "./settings-modal.tsx";
 import { VolumeSlider } from "../volume-slider/volume-slider.tsx";
 import { CallState } from "../../global-state/types.ts";
 import { ExitCallButton } from "./exit-call-button.tsx";
@@ -47,18 +45,12 @@ import { ModalConfirmationText } from "../modal/modal-confirmation-text.ts";
 import { SymphonyRtcConnectionComponent } from "./symphony-rtc-connection-component.tsx";
 import { ReloadDevicesButton } from "../reload-devices-button.tsx/reload-devices-button.tsx";
 import { useFetchDevices } from "../../hooks/use-fetch-devices.ts";
+import { HotkeysComponent } from "./hotkeys-component.tsx";
 
 type FormValues = TJoinProductionOptions;
 
 const TempDiv = styled.div`
   padding: 0 0 2rem 0;
-`;
-
-const HotkeyDiv = styled.div`
-  padding: 0 0 2rem 0;
-  flex-direction: row;
-  display: flex;
-  align-items: center;
 `;
 
 const HeaderWrapper = styled.div`
@@ -80,15 +72,6 @@ const ButtonIcon = styled.div`
   display: inline-block;
   vertical-align: middle;
   margin: 0 auto;
-`;
-
-const SettingsBtn = styled.div`
-  padding: 0;
-  margin-left: 1.5rem;
-  width: 3rem;
-  cursor: pointer;
-  color: white;
-  background: transparent;
 `;
 
 const FlexButtonWrapper = styled.div`
@@ -154,12 +137,16 @@ type TProductionLine = {
   id: string;
   callState: CallState;
   isSingleCall: boolean;
+  customGlobalMute: string;
+  masterInputMute: boolean;
 };
 
 export const ProductionLine = ({
   id,
   callState,
   isSingleCall,
+  customGlobalMute,
+  masterInputMute,
 }: TProductionLine) => {
   const { productionId: paramProductionId, lineId: paramLineId } = useParams();
   const [{ devices }, dispatch] = useGlobalState();
@@ -168,23 +155,8 @@ export const ProductionLine = ({
   const [isOutputMuted, setIsOutputMuted] = useState(false);
   const [showDeviceSettings, setShowDeviceSettings] = useState(false);
   const [refresh, setRefresh] = useState<number>(0);
-  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [confirmExitModalOpen, setConfirmExitModalOpen] = useState(false);
   const [value, setValue] = useState(0.75);
-  const [hotkeys, setHotkeys] = useState<Hotkeys>({
-    muteHotkey: "m",
-    speakerHotkey: "n",
-    pressToTalkHotkey: "t",
-    increaseVolumeHotkey: "u",
-    decreaseVolumeHotkey: "d",
-  });
-  const [savedHotkeys, setSavedHotkeys] = useState<Hotkeys>({
-    muteHotkey: "m",
-    speakerHotkey: "n",
-    pressToTalkHotkey: "t",
-    increaseVolumeHotkey: "u",
-    decreaseVolumeHotkey: "d",
-  });
   const {
     joinProductionOptions,
     dominantSpeaker,
@@ -192,6 +164,7 @@ export const ProductionLine = ({
     connectionState,
     audioElements,
     sessionId,
+    hotkeys: savedHotkeys,
   } = callState;
 
   const [inputAudioStream, resetAudioInput] = useAudioInput({
@@ -219,7 +192,7 @@ export const ProductionLine = ({
     // TODO: Fix for iOS
   };
 
-  useHotkeys(savedHotkeys.increaseVolumeHotkey || "u", () => {
+  useHotkeys(savedHotkeys?.increaseVolumeHotkey || "u", () => {
     const newValue = Math.min(value + 0.05, 1);
     setValue(newValue);
 
@@ -229,7 +202,7 @@ export const ProductionLine = ({
     });
   });
 
-  useHotkeys(savedHotkeys.decreaseVolumeHotkey || "d", () => {
+  useHotkeys(savedHotkeys?.decreaseVolumeHotkey || "d", () => {
     const newValue = Math.max(value - 0.05, 0);
     setValue(newValue);
 
@@ -266,8 +239,8 @@ export const ProductionLine = ({
   useLineHotkeys({
     muteInput,
     isInputMuted,
-    customKeyMute: savedHotkeys.muteHotkey,
-    customKeyPress: savedHotkeys.pressToTalkHotkey,
+    customKeyMute: savedHotkeys?.muteHotkey || "m",
+    customKeyPress: savedHotkeys?.pushToTalkHotkey || "t",
   });
 
   useFetchDevices({
@@ -291,6 +264,16 @@ export const ProductionLine = ({
   }, [joinProductionOptions]);
 
   useEffect(() => {
+    if (inputAudioStream && inputAudioStream !== "no-device") {
+      inputAudioStream.getTracks().forEach((t) => {
+        // eslint-disable-next-line no-param-reassign
+        t.enabled = !masterInputMute;
+      });
+      setIsInputMuted(masterInputMute);
+    }
+  }, [inputAudioStream, masterInputMute]);
+
+  useEffect(() => {
     if (connectionState === "connected") {
       playEnterSound();
     }
@@ -309,7 +292,7 @@ export const ProductionLine = ({
   useSpeakerHotkeys({
     muteOutput,
     isOutputMuted,
-    customKey: savedHotkeys.speakerHotkey,
+    customKey: savedHotkeys?.speakerHotkey || "n",
   });
 
   const line = useLinePolling({ callId: id, joinProductionOptions });
@@ -417,15 +400,6 @@ export const ProductionLine = ({
 
       setShowDeviceSettings(false);
     }
-  };
-
-  const handleSettingsClick = () => {
-    setIsSettingsModalOpen(!isSettingsModalOpen);
-  };
-
-  const saveHotkeys = () => {
-    setSavedHotkeys({ ...hotkeys });
-    setIsSettingsModalOpen(false);
   };
 
   // TODO detect if browser back button is pressed and run exit();
@@ -627,51 +601,12 @@ export const ProductionLine = ({
               {inputAudioStream &&
                 inputAudioStream !== "no-device" &&
                 !isMobile && (
-                  <>
-                    <HotkeyDiv>
-                      <strong>Hotkeys</strong>
-                      <SettingsBtn onClick={handleSettingsClick}>
-                        <SettingsIcon />
-                      </SettingsBtn>
-                    </HotkeyDiv>
-                    <TempDiv>
-                      <strong>{savedHotkeys.muteHotkey.toUpperCase()}: </strong>
-                      Toggle Input Mute
-                    </TempDiv>
-                    <TempDiv>
-                      <strong>
-                        {savedHotkeys.speakerHotkey.toUpperCase()}:{" "}
-                      </strong>
-                      Toggle Output Mute
-                    </TempDiv>
-                    <TempDiv>
-                      <strong>
-                        {savedHotkeys.pressToTalkHotkey.toUpperCase()}:{" "}
-                      </strong>
-                      Push to Talk
-                    </TempDiv>
-                    <TempDiv>
-                      <strong>
-                        {savedHotkeys.increaseVolumeHotkey.toUpperCase()}:{" "}
-                      </strong>
-                      Increase Volume
-                    </TempDiv>
-                    <TempDiv>
-                      <strong>
-                        {savedHotkeys.decreaseVolumeHotkey.toUpperCase()}:{" "}
-                      </strong>
-                      Decrease Volume
-                    </TempDiv>
-                    {isSettingsModalOpen && (
-                      <SettingsModal
-                        hotkeys={hotkeys}
-                        lineName={line?.name}
-                        setHotkeys={setHotkeys}
-                        onSave={saveHotkeys}
-                        onClose={handleSettingsClick}
-                      />
-                    )}
-                  </>
+                  <HotkeysComponent
+                    callId={id}
+                    savedHotkeys={savedHotkeys}
+                    customGlobalMute={customGlobalMute}
+                    line={line}
+                  />
                 )}
             </div>
           </ListWrapper>

--- a/src/components/production-line/rtc-stat-interval.ts
+++ b/src/components/production-line/rtc-stat-interval.ts
@@ -11,6 +11,7 @@ export const startRtcStatInterval = ({
   dispatch: Dispatch<TGlobalStateAction>;
 }) => {
   let ongoingStatsPromise: null | Promise<void | RTCStatsReport> = null;
+  let previousState = false;
 
   const statsInterval = window.setInterval(() => {
     // Do not request new stats if previously requested has not yet resolved
@@ -67,16 +68,19 @@ export const startRtcStatInterval = ({
           }
         });
       }
+      if (previousState !== isAudioLevelAboveThreshold) {
+        previousState = isAudioLevelAboveThreshold;
 
-      dispatch({
-        type: "UPDATE_CALL",
-        payload: {
-          id: callId,
-          updates: {
-            audioLevelAboveThreshold: isAudioLevelAboveThreshold,
+        dispatch({
+          type: "UPDATE_CALL",
+          payload: {
+            id: callId,
+            updates: {
+              audioLevelAboveThreshold: isAudioLevelAboveThreshold,
+            },
           },
-        },
-      });
+        });
+      }
     });
   }, 100);
 

--- a/src/components/production-line/types.ts
+++ b/src/components/production-line/types.ts
@@ -9,6 +9,15 @@ export type TJoinProductionOptions = {
   audiooutput: string | null;
 };
 
+export type Hotkeys = {
+  muteHotkey: string;
+  speakerHotkey: string;
+  pushToTalkHotkey: string;
+  increaseVolumeHotkey: string;
+  decreaseVolumeHotkey: string;
+  globalMuteHotkey: string;
+};
+
 export type TParticipant = {
   name: string;
   sessionId: string;

--- a/src/components/production-line/use-check-for-duplicate-hotkey.tsx
+++ b/src/components/production-line/use-check-for-duplicate-hotkey.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { useGlobalState } from "../../global-state/context-provider.tsx";
+import { Hotkeys } from "./types.ts";
+
+type TProps = {
+  callId: string;
+  hotkeys: Hotkeys;
+};
+export const useCheckForDuplicateHotkey = ({ callId, hotkeys }: TProps) => {
+  const [hotkeysDuplicate, setHotkeysDuplicate] = useState<string[] | null>(
+    null
+  );
+  const [{ calls }] = useGlobalState();
+
+  useEffect(() => {
+    if (!calls || !hotkeys || !callId) return;
+
+    const newDuplicates = new Set<string>();
+
+    Object.entries(calls).forEach(([id, callState]) => {
+      if (id === callId) return; // Skip the current setup
+
+      const hotkeysInGlobalState = Object.entries(callState.hotkeys);
+      const hotkeysLocalState = Object.entries(hotkeys);
+
+      hotkeysInGlobalState.forEach(([globalKey, globalValue]) => {
+        hotkeysLocalState.forEach(([localKey, localValue]) => {
+          // Skip comparison if both keys are "globalMuteHotkey"
+          if (
+            globalKey === "globalMuteHotkey" &&
+            localKey === "globalMuteHotkey"
+          ) {
+            return;
+          }
+
+          // Add duplicate if values match
+          if (globalValue === localValue) {
+            newDuplicates.add(localValue);
+          }
+        });
+      });
+    });
+
+    // Update state with unique duplicates
+    setHotkeysDuplicate((prev) => {
+      const updatedDuplicates = prev
+        ? new Set([...prev, ...Array.from(newDuplicates)])
+        : newDuplicates;
+      return Array.from(updatedDuplicates);
+    });
+  }, [callId, calls, hotkeys]);
+
+  return hotkeysDuplicate;
+};

--- a/src/components/production-line/use-line-hotkeys.ts
+++ b/src/components/production-line/use-line-hotkeys.ts
@@ -13,6 +13,12 @@ type TuseSpeakerHotkeys = {
   customKey?: string;
 };
 
+type TuseGlobalHotkeys = {
+  muteInput: (mute: boolean) => void;
+  isInputMuted: boolean;
+  customKey?: string;
+};
+
 export const useLineHotkeys = ({
   muteInput,
   isInputMuted,
@@ -51,5 +57,17 @@ export const useSpeakerHotkeys = ({
 
   useHotkeys(muteOutputKey, () => {
     muteOutput(!isOutputMuted);
+  });
+};
+
+export const useGlobalHotkeys = ({
+  muteInput,
+  isInputMuted,
+  customKey,
+}: TuseGlobalHotkeys) => {
+  const muteInputKey = customKey || "p";
+
+  useHotkeys(muteInputKey, () => {
+    muteInput(!isInputMuted);
   });
 };

--- a/src/components/production-line/use-update-global-hotkey.tsx
+++ b/src/components/production-line/use-update-global-hotkey.tsx
@@ -1,0 +1,39 @@
+import { useGlobalState } from "../../global-state/context-provider.tsx";
+import { Hotkeys } from "./types.ts";
+
+type TProps = {
+  callId: string;
+  hotkeys: Hotkeys;
+};
+export const useUpdateGlobalHotkey = () => {
+  const [{ calls }, dispatch] = useGlobalState();
+
+  const updateGlobalHotkey = ({ callId, hotkeys }: TProps) => {
+    dispatch({
+      type: "UPDATE_CALL",
+      payload: {
+        id: callId,
+        updates: {
+          hotkeys: { ...hotkeys },
+        },
+      },
+    });
+    Object.entries(calls).forEach(([id, callState]) => {
+      if (id === callId) return;
+      dispatch({
+        type: "UPDATE_CALL",
+        payload: {
+          id,
+          updates: {
+            hotkeys: {
+              ...callState.hotkeys,
+              globalMuteHotkey: hotkeys.globalMuteHotkey,
+            },
+          },
+        },
+      });
+    });
+  };
+
+  return [updateGlobalHotkey];
+};

--- a/src/components/production-list/production-list-item.tsx
+++ b/src/components/production-list/production-list-item.tsx
@@ -164,6 +164,14 @@ export const ProductionsListItem = ({
             connectionState: null,
             audioElements: null,
             sessionId: null,
+            hotkeys: {
+              muteHotkey: "m",
+              speakerHotkey: "n",
+              pushToTalkHotkey: "t",
+              increaseVolumeHotkey: "u",
+              decreaseVolumeHotkey: "d",
+              globalMuteHotkey: "p",
+            },
           },
         },
       });

--- a/src/global-state/types.ts
+++ b/src/global-state/types.ts
@@ -1,4 +1,5 @@
 import {
+  Hotkeys,
   TJoinProductionOptions,
   TProduction,
 } from "../components/production-line/types.ts";
@@ -18,6 +19,7 @@ export interface CallState {
   connectionState: RTCPeerConnectionState | null;
   audioElements: HTMLAudioElement[] | null;
   sessionId: string | null;
+  hotkeys: Hotkeys;
 }
 
 export type TGlobalState = {


### PR DESCRIPTION
# What does this do?

## Changed logic

Hotkeys are now added to the global-state and added to each callState. This allows for a more complete experience with using the hotkeys.

## Warnings and Errors

We still want to be able to block users from saving faulty hotkey-setups, these messages are now red and if a red message is present then saving wont be possible. If a yellow message is shown then it will be a warning to the user that a key used in another call is about to be added. This might be desirable so saving wont be blocked.

<img width="547" alt="Screenshot 2024-12-20 at 16 19 54" src="https://github.com/user-attachments/assets/5aeac7e7-e4ab-4635-bd0d-fdd8464f38c5" />

## Added Master-Mute

A button for toggling the microphone mute-button is added. It is changeable from the hotkey-settings and when updated it will be updated for all current calls and all calls added on afterwards.

<img width="672" alt="Screenshot 2024-12-20 at 16 21 47" src="https://github.com/user-attachments/assets/4ff4016a-ed56-4e05-9854-ac23fe1574f7" />

## Minor fixes

- Updated logic behind "audioLevelAboveThreshold" to make it stop updating every 100ms, now it only updates when the value is changed
- Updated back-btn css
- Changed "Press To Talk" to more commonly used "Push To Talk"
