### PR TITLE
Feat/mute participant

### DIFF
--- a/src/components/landing-page/join-production.tsx
+++ b/src/components/landing-page/join-production.tsx
@@ -181,6 +181,8 @@ export const JoinProduction = ({
           connectionState: null,
           audioElements: null,
           sessionId: null,
+          dataChannel: null,
+          isRemotelyMuted: false,
           hotkeys: {
             muteHotkey: "m",
             speakerHotkey: "n",

--- a/src/components/modal/modal-confirmation-text.ts
+++ b/src/components/modal/modal-confirmation-text.ts
@@ -2,4 +2,8 @@ import styled from "@emotion/styled";
 
 export const ModalConfirmationText = styled.p`
   padding-bottom: 1rem;
+
+  &.bold {
+    font-weight: bold;
+  }
 `;

--- a/src/components/production-line/use-rtc-connection.ts
+++ b/src/components/production-line/use-rtc-connection.ts
@@ -127,6 +127,16 @@ const establishConnection = ({
     }
   );
 
+  dispatch({
+    type: "UPDATE_CALL",
+    payload: {
+      id: callId,
+      updates: {
+        dataChannel,
+      },
+    },
+  });
+
   const onDataChannelMessage = ({ data }: MessageEvent) => {
     let message: unknown;
 
@@ -150,6 +160,30 @@ const establishConnection = ({
           id: callId,
           updates: {
             dominantSpeaker: message.endpoint,
+          },
+        },
+      });
+    } else if (
+      message &&
+      typeof message === "object" &&
+      "type" in message &&
+      message.type === "EndpointMessage" &&
+      "payload" in message &&
+      "to" in message &&
+      "from" in message &&
+      message.payload &&
+      typeof message.payload === "object" &&
+      "muteParticipant" in message.payload &&
+      typeof message.payload.muteParticipant === "string"
+    ) {
+      dispatch({
+        type: "UPDATE_CALL",
+        payload: {
+          id: callId,
+          updates: {
+            isRemotelyMuted:
+              message.payload.muteParticipant === "mute" &&
+              message.to !== message.from,
           },
         },
       });

--- a/src/components/production-line/user-list.tsx
+++ b/src/components/production-line/user-list.tsx
@@ -138,7 +138,7 @@ export const UserList = ({
                 </IsTalkingIndicator>
                 {p.name} {p.isActive ? "" : "(inactive)"}
               </User>
-              {!isYou && (
+              {!isYou && p.isActive && (
                 <MuteParticipantButton
                   onClick={() => {
                     setUserId(p.endpointId);

--- a/src/components/production-line/user-list.tsx
+++ b/src/components/production-line/user-list.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { DisplayContainerHeader } from "../landing-page/display-container-header.tsx";
 import { TParticipant } from "./types.ts";
-import { UserIcon } from "../../assets/icons/icon.tsx";
+import { MicMuted, UserIcon } from "../../assets/icons/icon.tsx";
 
 const Container = styled.div`
   width: 100%;
@@ -26,11 +26,12 @@ type TIndicatorProps = {
   isActive: boolean;
 };
 
-const User = styled.div<TUserProps>`
+const UserWrapper = styled.div<TUserProps>`
   display: flex;
   align-items: center;
-  background: #1a1a1a;
+  justify-content: space-between;
   padding: 1rem;
+  background: #1a1a1a;
   color: #ddd;
   border: transparent;
   border-bottom: 0.1rem solid #464646;
@@ -45,6 +46,11 @@ const User = styled.div<TUserProps>`
   }
 
   ${({ isYou }) => (isYou ? `background: #353434;` : "")}
+`;
+
+const User = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
 const IsTalkingIndicator = styled.div<TIsTalkingIndicator>`
@@ -79,11 +85,24 @@ const IconWrapper = styled.div`
   width: 2rem;
 `;
 
+const MuteParticipantButton = styled.button`
+  width: 3rem;
+  padding: 0.3rem;
+  margin: 0;
+  background: #302b2b;
+  border: 0.1rem solid #707070;
+  border-radius: 0.4rem;
+  cursor: pointer;
+`;
+
 type TUserListOptions = {
   participants: TParticipant[];
   sessionId: string | null;
   dominantSpeaker: string | null;
   audioLevelAboveThreshold: boolean;
+  setConfirmModalOpen: (value: boolean) => void;
+  setUserId: (value: string) => void;
+  setUserName: (value: string) => void;
 };
 
 export const UserList = ({
@@ -91,6 +110,9 @@ export const UserList = ({
   sessionId,
   dominantSpeaker,
   audioLevelAboveThreshold,
+  setConfirmModalOpen,
+  setUserId,
+  setUserName,
 }: TUserListOptions) => {
   if (!participants) return null;
 
@@ -98,22 +120,38 @@ export const UserList = ({
     <Container>
       <DisplayContainerHeader>Participants</DisplayContainerHeader>
       <ListWrapper>
-        {participants.map((p) => (
-          <User key={p.sessionId} isYou={p.sessionId === sessionId}>
-            <IsTalkingIndicator
-              isTalking={
-                audioLevelAboveThreshold && p.endpointId === dominantSpeaker
-              }
-            >
-              <OnlineIndicator isActive={p.isActive}>
-                <IconWrapper>
-                  <UserIcon />
-                </IconWrapper>
-              </OnlineIndicator>
-            </IsTalkingIndicator>
-            {p.name} {p.isActive ? "" : "(inactive)"}
-          </User>
-        ))}
+        {participants.map((p) => {
+          const isYou = p.sessionId === sessionId;
+          return (
+            <UserWrapper key={p.sessionId} isYou={isYou}>
+              <User>
+                <IsTalkingIndicator
+                  isTalking={
+                    audioLevelAboveThreshold && p.endpointId === dominantSpeaker
+                  }
+                >
+                  <OnlineIndicator isActive={p.isActive}>
+                    <IconWrapper>
+                      <UserIcon />
+                    </IconWrapper>
+                  </OnlineIndicator>
+                </IsTalkingIndicator>
+                {p.name} {p.isActive ? "" : "(inactive)"}
+              </User>
+              {!isYou && (
+                <MuteParticipantButton
+                  onClick={() => {
+                    setUserId(p.endpointId);
+                    setUserName(p.name);
+                    setConfirmModalOpen(true);
+                  }}
+                >
+                  <MicMuted />
+                </MuteParticipantButton>
+              )}
+            </UserWrapper>
+          );
+        })}
       </ListWrapper>
     </Container>
   );

--- a/src/components/production-list/production-list-item.tsx
+++ b/src/components/production-list/production-list-item.tsx
@@ -164,6 +164,8 @@ export const ProductionsListItem = ({
             connectionState: null,
             audioElements: null,
             sessionId: null,
+            dataChannel: null,
+            isRemotelyMuted: false,
             hotkeys: {
               muteHotkey: "m",
               speakerHotkey: "n",

--- a/src/global-state/types.ts
+++ b/src/global-state/types.ts
@@ -20,6 +20,8 @@ export interface CallState {
   audioElements: HTMLAudioElement[] | null;
   sessionId: string | null;
   hotkeys: Hotkeys;
+  dataChannel: RTCDataChannel | null;
+  isRemotelyMuted: boolean;
 }
 
 export type TGlobalState = {


### PR DESCRIPTION
# What does this do?

## Mute other participant

A mute button is added to the user-list that triggers a message to that participant, if it is active. When the message is received that sets the user's mic to mute. It is then reseted when the user unmutes it's microphone.

![Screenshot 2025-01-09 at 10 27 59](https://github.com/user-attachments/assets/3e38a547-48e7-45b0-aaed-0e8d970defa0)

## Confirmation modal

To mute a participant the user has to click on a confirm button, that informs that the audio will be turned of for the entire call and not only for yourself.

<img width="471" alt="Screenshot 2025-01-09 at 09 42 25" src="https://github.com/user-attachments/assets/418188d6-68df-44d7-9604-afe0f6c93f66" />
