### PR TITLE
fix: added color for disabled buttons when actionbutton is used

### DIFF
--- a/src/components/landing-page/form-elements.tsx
+++ b/src/components/landing-page/form-elements.tsx
@@ -159,6 +159,10 @@ export const PrimaryButton = styled(ActionButton)`
   &:not(:disabled):active {
     transform: translateY(0.125rem);
   }
+
+  &:disabled {
+    background: rgba(89, 203, 232, 0.5);
+  }
 `;
 
 export const SecondaryButton = styled(ActionButton)`
@@ -216,5 +220,9 @@ export const SecondaryButton = styled(ActionButton)`
     left: 0.4rem;
     right: 0.4rem;
     top: 0.4rem;
+  }
+
+  &:disabled {
+    background: rgba(255, 255, 255, 0.8);
   }
 `;

--- a/src/components/production-line/settings-modal.tsx
+++ b/src/components/production-line/settings-modal.tsx
@@ -55,6 +55,10 @@ const ModalCloseButton = styled.button`
 
 const CancelButton = styled(ActionButton)`
   background: #d6d3d1;
+
+  &:disabled {
+    background: rgba(214, 211, 209, 0.8);
+  }
 `;
 
 const ButtonDiv = styled.div`

--- a/src/components/remove-button/remove-button.tsx
+++ b/src/components/remove-button/remove-button.tsx
@@ -12,6 +12,10 @@ const RemoveBtn = styled(ActionButton)`
   &:active:enabled {
     background: #990f0f;
   }
+
+  &:disabled {
+    background: rgba(220, 38, 38, 0.8);
+  }
 `;
 
 type TRemoveButton = {

--- a/src/components/verify-decision/verify-decision.tsx
+++ b/src/components/verify-decision/verify-decision.tsx
@@ -18,6 +18,10 @@ const VerifyButtons = styled.div`
 const CancelButton = styled(ActionButton)`
   background: #d6d3d1;
   color: "#27272a";
+
+  &:disabled {
+    background: rgba(214, 211, 209, 0.8);
+  }
 `;
 
 export const VerifyDecision = ({ loader, confirm, abort }: TVerifyDecision) => {


### PR DESCRIPTION
If no disabled-color is added then the button will always use the default green, which is a problem if the button-color is another color than default green.