### PR TITLE
fix: speaker-icon is red when audio-output is 0

### DIFF
--- a/src/components/production-line/minified-user-controls.tsx
+++ b/src/components/production-line/minified-user-controls.tsx
@@ -39,7 +39,7 @@ export const MinifiedUserControls = ({
         {line &&
           !(line?.programOutputLine && joinProductionOptions.isProgramUser) && (
             <MinifiedControlsButton
-              className={isOutputMuted ? "off" : "on"}
+              className={isOutputMuted || value === 0 ? "off" : "on"}
               onClick={setIsOutputMuted}
             >
               {isOutputMuted || value === 0 ? <SpeakerOff /> : <SpeakerOn />}

--- a/src/components/production-line/user-controls.tsx
+++ b/src/components/production-line/user-controls.tsx
@@ -54,7 +54,9 @@ export const UserControls = ({
               onClick={muteOutput}
               disabled={value === 0}
             >
-              <ButtonIcon className={isOutputMuted ? "mute" : "unmuted"}>
+              <ButtonIcon
+                className={isOutputMuted || value === 0 ? "mute" : "unmuted"}
+              >
                 {isOutputMuted || value === 0 ? <SpeakerOff /> : <SpeakerOn />}
               </ButtonIcon>
             </UserControlBtn>


### PR DESCRIPTION
<img width="235" alt="Screenshot 2025-01-17 at 16 55 42" src="https://github.com/user-attachments/assets/bdf136b4-4fe1-4674-af7f-50a005c99d75" />
