### PR TITLE
Feat/visual production

### DIFF
--- a/src/components/landing-page/join-production.tsx
+++ b/src/components/landing-page/join-production.tsx
@@ -29,6 +29,22 @@ import { RemoveIcon } from "../../assets/icons/icon.tsx";
 
 type FormValues = TJoinProductionOptions;
 
+const NameWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 2rem;
+`;
+
+const ProductionName = styled.p`
+  margin-bottom: 1rem;
+
+  &.name {
+    font-weight: bold;
+    min-height: 1.5rem;
+    margin: 0 0 0 0.5rem;
+  }
+`;
+
 const FetchErrorMessage = styled.div`
   background: ${errorColour};
   color: ${darkText};
@@ -291,6 +307,12 @@ export const JoinProduction = ({
         <>
           {!preSelected && (
             <>
+              <NameWrapper>
+                <ProductionName>Production name</ProductionName>
+                <ProductionName className="name">
+                  {production?.name || "Enter a production ID"}
+                </ProductionName>
+              </NameWrapper>
               <FormInputWithLoader
                 onChange={(ev) => {
                   onChange(ev);

--- a/src/components/production-line/call-header.tsx
+++ b/src/components/production-line/call-header.tsx
@@ -9,6 +9,7 @@ import {
   ProductionName,
   ParticipantCount,
   HeaderIcon,
+  Id,
 } from "../production-list/production-list-components";
 import { AudioFeedIcon, CallHeader } from "./production-line-components";
 import { TLine, TProduction } from "./types";
@@ -44,8 +45,12 @@ export const CallHeaderComponent = ({
           </AudioFeedIcon>
         )}
         <ProductionName
-          title={`${production?.name} / ${line?.name}`}
-        >{`${truncatedProductionName} / ${truncatedLineName}`}</ProductionName>
+          title={`${production?.name} (id: ${production?.productionId}) / ${line?.name}`}
+        >
+          {`${truncatedProductionName}`}
+          <Id>{`(id: ${production?.productionId})`}</Id>
+          {`/ ${truncatedLineName}`}
+        </ProductionName>
         <UsersIcon />
         <ParticipantCount>{line?.participants.length}</ParticipantCount>
       </HeaderTexts>

--- a/src/components/production-list/production-list-components.ts
+++ b/src/components/production-list/production-list-components.ts
@@ -17,11 +17,16 @@ export const ProductionItemWrapper = styled.div`
 `;
 
 export const ProductionName = styled.div`
+  display: flex;
   font-size: 1.4rem;
   font-weight: bold;
   margin-right: 1rem;
   max-width: 30rem;
   word-break: break-word;
+`;
+
+export const Id = styled.p`
+  font-weight: normal;
 `;
 
 export const ParticipantCount = styled.div`

--- a/src/components/production-list/production-list-item.tsx
+++ b/src/components/production-list/production-list-item.tsx
@@ -21,6 +21,7 @@ import {
   HeaderTexts,
   HeaderWrapper,
   IconWrapper,
+  Id,
   InnerDiv,
   Lineblock,
   LineBlockParticipant,
@@ -151,6 +152,7 @@ export const ProductionsListItem = ({
             {production.name.length > 40
               ? `${production.name.slice(0, 40)}...`
               : production.name}
+            <Id>{`(id: ${production?.productionId})`}</Id>
           </ProductionName>
           <UsersIcon />
           <ParticipantCount>{totalParticipants}</ParticipantCount>


### PR DESCRIPTION
# Quick Fix!
Added ID to where "Production Name" is displayed, so that the user knows it exists. It used to be part of the launchpage join-call, but was removed with the new UI. 

This will preferably be updated so that ID is not the main search-method, that the "Production Name" is searchable instead.

<img width="447" alt="Screenshot 2025-01-23 at 09 43 54" src="https://github.com/user-attachments/assets/152f05f2-2fca-4296-aafd-9653256396f3" />
<img width="483" alt="Screenshot 2025-01-23 at 09 44 56" src="https://github.com/user-attachments/assets/a0ab7252-4f82-4192-bda7-faaced66a8f3" />
<img width="502" alt="Screenshot 2025-01-23 at 09 51 24" src="https://github.com/user-attachments/assets/dba95d81-27f6-464a-84be-b5d20940463e" />
