### PR TITLE
feat: added visual feedback when line-activity

### DIFF
--- a/src/components/production-line/production-line-components.ts
+++ b/src/components/production-line/production-line-components.ts
@@ -134,13 +134,29 @@ export const LoaderWrapper = styled.div`
   height: 2rem;
 `;
 
-export const CallWrapper = styled.div`
+export const CallWrapper = styled.div<{ isSomeoneSpeaking: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
   margin: 0 0 2rem 0;
   min-width: 20rem;
+  background-color: transparent;
+  border-radius: 0.5rem;
+  animation: ${({ isSomeoneSpeaking }) =>
+    isSomeoneSpeaking ? "pulsate 1.5s ease-in-out infinite" : "none"};
+
+  @keyframes pulsate {
+    0% {
+      background-color: transparent;
+    }
+    50% {
+      background-color: rgba(255, 0, 68, 0.23);
+    }
+    100% {
+      background-color: transparent;
+    }
+  }
 `;
 
 export const CallContainer = styled(ProductionItemWrapper)<{

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -41,6 +41,7 @@ import { useLinePolling } from "./use-line-polling.ts";
 import { useMuteInput } from "./use-mute-input.tsx";
 import { UserControls } from "./user-controls.tsx";
 import { UserList } from "./user-list.tsx";
+import { useActiveParticipant } from "./use-active-participant.tsx";
 
 type TProductionLine = {
   id: string;
@@ -87,6 +88,7 @@ export const ProductionLine = ({
   } = callState;
 
   const increaseVolumeTimeoutRef = useRef<number | null>(null);
+  const { activeParticipant } = useActiveParticipant(audioLevelAboveThreshold);
 
   const [inputAudioStream, resetAudioInput] = useAudioInput({
     audioInputId: joinProductionOptions?.audioinput ?? null,
@@ -96,6 +98,9 @@ export const ProductionLine = ({
   const isProgramOutputLine = line && line.programOutputLine;
   const isProgramUser =
     joinProductionOptions && joinProductionOptions.isProgramUser;
+  const isSelfDominantSpeaker =
+    line?.participants.find((p) => p.sessionId === callState.sessionId)
+      ?.endpointId === dominantSpeaker;
 
   const { production, error: fetchProductionError } = useFetchProduction(
     joinProductionOptions
@@ -339,7 +344,11 @@ export const ProductionLine = ({
   // TODO detect if browser back button is pressed and run exit();
 
   return (
-    <CallWrapper>
+    <CallWrapper
+      isSomeoneSpeaking={
+        !isProgramOutputLine && !isSelfDominantSpeaker && activeParticipant
+      }
+    >
       {joinProductionOptions &&
         loading &&
         (!connectionError ? (

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useNavigate, useParams } from "react-router-dom";
 import { isMobile, isTablet } from "../../bowser.ts";
@@ -88,7 +88,9 @@ export const ProductionLine = ({
   } = callState;
 
   const increaseVolumeTimeoutRef = useRef<number | null>(null);
-  const { activeParticipant } = useActiveParticipant(audioLevelAboveThreshold);
+  const { isActiveParticipant } = useActiveParticipant(
+    audioLevelAboveThreshold
+  );
 
   const [inputAudioStream, resetAudioInput] = useAudioInput({
     audioInputId: joinProductionOptions?.audioinput ?? null,
@@ -98,9 +100,13 @@ export const ProductionLine = ({
   const isProgramOutputLine = line && line.programOutputLine;
   const isProgramUser =
     joinProductionOptions && joinProductionOptions.isProgramUser;
-  const isSelfDominantSpeaker =
-    line?.participants.find((p) => p.sessionId === callState.sessionId)
-      ?.endpointId === dominantSpeaker;
+
+  const isSelfDominantSpeaker = useMemo(
+    () =>
+      line?.participants.find((p) => p.sessionId === callState.sessionId)
+        ?.endpointId === dominantSpeaker,
+    [line?.participants, callState.sessionId, dominantSpeaker]
+  );
 
   const { production, error: fetchProductionError } = useFetchProduction(
     joinProductionOptions
@@ -346,7 +352,7 @@ export const ProductionLine = ({
   return (
     <CallWrapper
       isSomeoneSpeaking={
-        !isProgramOutputLine && !isSelfDominantSpeaker && activeParticipant
+        !isProgramOutputLine && !isSelfDominantSpeaker && isActiveParticipant
       }
     >
       {joinProductionOptions &&

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -101,12 +101,14 @@ export const ProductionLine = ({
   const isProgramUser =
     joinProductionOptions && joinProductionOptions.isProgramUser;
 
-  const isSelfDominantSpeaker = useMemo(
+  const lineParticipant = useMemo(
     () =>
       line?.participants.find((p) => p.sessionId === callState.sessionId)
-        ?.endpointId === dominantSpeaker,
-    [line?.participants, callState.sessionId, dominantSpeaker]
+        ?.endpointId,
+    [line?.participants, callState.sessionId]
   );
+
+  const isSelfDominantSpeaker = lineParticipant === dominantSpeaker;
 
   const { production, error: fetchProductionError } = useFetchProduction(
     joinProductionOptions

--- a/src/components/production-line/use-active-participant.tsx
+++ b/src/components/production-line/use-active-participant.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 
 export const useActiveParticipant = (audioLevelAboveThreshold: boolean) => {
-  const [activeParticipant, setActiveParticipant] = useState(false);
+  const [isActiveParticipant, setIsActiveParticipant] = useState(false);
+  const activeParticipantRef = useRef(false);
   const startSpeakingTimeoutRef = useRef<number | null>(null);
   const stopSpeakingTimeoutRef = useRef<number | null>(null);
 
@@ -12,9 +13,10 @@ export const useActiveParticipant = (audioLevelAboveThreshold: boolean) => {
         stopSpeakingTimeoutRef.current = null;
       }
 
-      if (!startSpeakingTimeoutRef.current && !activeParticipant) {
+      if (!startSpeakingTimeoutRef.current) {
         startSpeakingTimeoutRef.current = window.setTimeout(() => {
-          setActiveParticipant(true);
+          setIsActiveParticipant(true);
+          activeParticipantRef.current = true;
           startSpeakingTimeoutRef.current = null;
         }, 500);
       }
@@ -24,9 +26,10 @@ export const useActiveParticipant = (audioLevelAboveThreshold: boolean) => {
         startSpeakingTimeoutRef.current = null;
       }
 
-      if (activeParticipant && !stopSpeakingTimeoutRef.current) {
+      if (activeParticipantRef.current && !stopSpeakingTimeoutRef.current) {
         stopSpeakingTimeoutRef.current = window.setTimeout(() => {
-          setActiveParticipant(false);
+          setIsActiveParticipant(false);
+          activeParticipantRef.current = false;
           stopSpeakingTimeoutRef.current = null;
         }, 1000);
       }
@@ -40,7 +43,12 @@ export const useActiveParticipant = (audioLevelAboveThreshold: boolean) => {
         window.clearTimeout(stopSpeakingTimeoutRef.current);
       }
     };
-  }, [audioLevelAboveThreshold, activeParticipant]);
+  }, [audioLevelAboveThreshold]);
 
-  return { activeParticipant, setActiveParticipant };
+  // Keep ref in sync with state for external updates
+  useEffect(() => {
+    activeParticipantRef.current = isActiveParticipant;
+  }, [isActiveParticipant]);
+
+  return { isActiveParticipant, setIsActiveParticipant };
 };

--- a/src/components/production-line/use-active-participant.tsx
+++ b/src/components/production-line/use-active-participant.tsx
@@ -1,0 +1,46 @@
+import { useState, useRef, useEffect } from "react";
+
+export const useActiveParticipant = (audioLevelAboveThreshold: boolean) => {
+  const [activeParticipant, setActiveParticipant] = useState(false);
+  const startSpeakingTimeoutRef = useRef<number | null>(null);
+  const stopSpeakingTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (audioLevelAboveThreshold) {
+      if (stopSpeakingTimeoutRef.current) {
+        window.clearTimeout(stopSpeakingTimeoutRef.current);
+        stopSpeakingTimeoutRef.current = null;
+      }
+
+      if (!startSpeakingTimeoutRef.current && !activeParticipant) {
+        startSpeakingTimeoutRef.current = window.setTimeout(() => {
+          setActiveParticipant(true);
+          startSpeakingTimeoutRef.current = null;
+        }, 500);
+      }
+    } else {
+      if (startSpeakingTimeoutRef.current) {
+        window.clearTimeout(startSpeakingTimeoutRef.current);
+        startSpeakingTimeoutRef.current = null;
+      }
+
+      if (activeParticipant && !stopSpeakingTimeoutRef.current) {
+        stopSpeakingTimeoutRef.current = window.setTimeout(() => {
+          setActiveParticipant(false);
+          stopSpeakingTimeoutRef.current = null;
+        }, 1000);
+      }
+    }
+
+    return () => {
+      if (startSpeakingTimeoutRef.current) {
+        window.clearTimeout(startSpeakingTimeoutRef.current);
+      }
+      if (stopSpeakingTimeoutRef.current) {
+        window.clearTimeout(stopSpeakingTimeoutRef.current);
+      }
+    };
+  }, [audioLevelAboveThreshold, activeParticipant]);
+
+  return { activeParticipant, setActiveParticipant };
+};


### PR DESCRIPTION
There will be a pulsating background when there is audio-activity on a line that is not a "program output"-line, no pulsation if user is dominant speaker.

Video of the visual effect:
https://github.com/user-attachments/assets/4273b74e-6883-4e19-a6bf-243fb2e8494c

