### PR TITLE
feat: added copy-function to manage-page  and made copy more reusable

### DIFF
--- a/src/components/copy-button/copy-all-links-button.tsx
+++ b/src/components/copy-button/copy-all-links-button.tsx
@@ -1,0 +1,49 @@
+import styled from "@emotion/styled";
+import { PrimaryButton } from "../landing-page/form-elements";
+import { useCopyLinks } from "./use-copy-links";
+import { TProduction } from "../production-line/types";
+import { CheckIcon } from "../../assets/icons/icon";
+
+const CopyToClipboardWrapper = styled.div<{
+  flexDirection: "row" | "row-reverse";
+}>`
+  display: flex;
+  flex-direction: ${({ flexDirection }) => flexDirection};
+  align-items: center;
+
+  svg {
+    width: 4rem;
+    height: 4rem;
+    padding: 1rem 0 1rem 0;
+    fill: #76e859;
+  }
+`;
+
+export const CopyAllLinksButton = ({
+  production,
+  flexDirection,
+}: {
+  production: TProduction;
+  flexDirection: "row" | "row-reverse";
+}) => {
+  const { isCopied, handleCopyUrlToClipboard } = useCopyLinks();
+
+  return (
+    <CopyToClipboardWrapper flexDirection={flexDirection}>
+      <PrimaryButton
+        type="button"
+        onClick={() =>
+          handleCopyUrlToClipboard(
+            production.lines.map((item) => {
+              return ` ${item.name}: ${window.location.origin}/production-calls/production/${production.productionId}/line/${item.id}`;
+            })
+          )
+        }
+        disabled={isCopied}
+      >
+        Copy Links
+      </PrimaryButton>
+      {isCopied && <CheckIcon />}
+    </CopyToClipboardWrapper>
+  );
+};

--- a/src/components/copy-button/copy-all-links-button.tsx
+++ b/src/components/copy-button/copy-all-links-button.tsx
@@ -4,12 +4,17 @@ import { useCopyLinks } from "./use-copy-links";
 import { TProduction } from "../production-line/types";
 import { CheckIcon } from "../../assets/icons/icon";
 
-const CopyToClipboardWrapper = styled.div<{
-  flexDirection: "row" | "row-reverse";
-}>`
+const CopyToClipboardWrapper = styled.div`
   display: flex;
-  flex-direction: ${({ flexDirection }) => flexDirection};
   align-items: center;
+
+  &.manage-production-page {
+    flex-direction: row-reverse;
+  }
+
+  &.create-production-page {
+    flex-direction: row;
+  }
 
   svg {
     width: 4rem;
@@ -21,26 +26,24 @@ const CopyToClipboardWrapper = styled.div<{
 
 export const CopyAllLinksButton = ({
   production,
-  flexDirection,
+  className,
 }: {
   production: TProduction;
-  flexDirection: "row" | "row-reverse";
+  className: string;
 }) => {
   const { isCopied, handleCopyUrlToClipboard } = useCopyLinks();
 
+  const handleCopy = () => {
+    handleCopyUrlToClipboard(
+      production.lines.map((item) => {
+        return ` ${item.name}: ${window.location.origin}/production-calls/production/${production.productionId}/line/${item.id}`;
+      })
+    );
+  };
+
   return (
-    <CopyToClipboardWrapper flexDirection={flexDirection}>
-      <PrimaryButton
-        type="button"
-        onClick={() =>
-          handleCopyUrlToClipboard(
-            production.lines.map((item) => {
-              return ` ${item.name}: ${window.location.origin}/production-calls/production/${production.productionId}/line/${item.id}`;
-            })
-          )
-        }
-        disabled={isCopied}
-      >
+    <CopyToClipboardWrapper className={className}>
+      <PrimaryButton type="button" onClick={handleCopy} disabled={isCopied}>
         Copy Links
       </PrimaryButton>
       {isCopied && <CheckIcon />}

--- a/src/components/copy-button/copy-button.tsx
+++ b/src/components/copy-button/copy-button.tsx
@@ -1,0 +1,63 @@
+import styled from "@emotion/styled";
+import { CopyIcon, CheckIcon } from "../../assets/icons/icon";
+import { useCopyLinks } from "./use-copy-links";
+
+const IconWrapper = styled.div<{
+  isCopied: boolean;
+  buttonSize: string;
+  marginLeft: string;
+}>`
+  width: ${({ buttonSize }) => buttonSize};
+  height: ${({ buttonSize }) => buttonSize};
+  margin-left: ${({ marginLeft }) => marginLeft};
+  display: flex;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  transition:
+    transform 0.1s ease,
+    background 0.2s ease;
+
+  ${({ isCopied }) =>
+    !isCopied &&
+    `
+    &:active {
+    transform: scale(0.95);
+    background: rgba(0, 0, 0, 0.4);
+  }
+  `}
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.3);
+  }
+
+  svg {
+    fill: #59cbe8;
+  }
+`;
+
+export const CopyButton = ({
+  url,
+  buttonSize,
+  marginLeft,
+}: {
+  url: string;
+  buttonSize: string;
+  marginLeft: string;
+}) => {
+  const { isCopied, handleCopyUrlToClipboard } = useCopyLinks();
+
+  return (
+    <IconWrapper
+      title="Copy URL"
+      isCopied={isCopied}
+      buttonSize={buttonSize}
+      marginLeft={marginLeft}
+      onClick={() => {
+        if (isCopied) return;
+        handleCopyUrlToClipboard(url);
+      }}
+    >
+      {isCopied ? <CheckIcon /> : <CopyIcon />}
+    </IconWrapper>
+  );
+};

--- a/src/components/copy-button/copy-button.tsx
+++ b/src/components/copy-button/copy-button.tsx
@@ -4,12 +4,7 @@ import { useCopyLinks } from "./use-copy-links";
 
 const IconWrapper = styled.div<{
   isCopied: boolean;
-  buttonSize: string;
-  marginLeft: string;
 }>`
-  width: ${({ buttonSize }) => buttonSize};
-  height: ${({ buttonSize }) => buttonSize};
-  margin-left: ${({ marginLeft }) => marginLeft};
   display: flex;
   padding: 0.5rem;
   border-radius: 0.5rem;
@@ -30,6 +25,18 @@ const IconWrapper = styled.div<{
     background: rgba(0, 0, 0, 0.3);
   }
 
+  &.production-list-item {
+    width: 3rem;
+    height: 3rem;
+    margin-left: 0;
+  }
+
+  &.share-line-link-modal {
+    width: 4rem;
+    height: 4rem;
+    margin-left: 1rem;
+  }
+
   svg {
     fill: #59cbe8;
   }
@@ -37,25 +44,25 @@ const IconWrapper = styled.div<{
 
 export const CopyButton = ({
   url,
-  buttonSize,
-  marginLeft,
+  className,
 }: {
   url: string;
-  buttonSize: string;
-  marginLeft: string;
+  className: string;
 }) => {
   const { isCopied, handleCopyUrlToClipboard } = useCopyLinks();
+
+  const handleCopy = () => {
+    if (isCopied) return;
+
+    handleCopyUrlToClipboard(url);
+  };
 
   return (
     <IconWrapper
       title="Copy URL"
       isCopied={isCopied}
-      buttonSize={buttonSize}
-      marginLeft={marginLeft}
-      onClick={() => {
-        if (isCopied) return;
-        handleCopyUrlToClipboard(url);
-      }}
+      onClick={handleCopy}
+      className={className}
     >
       {isCopied ? <CheckIcon /> : <CopyIcon />}
     </IconWrapper>

--- a/src/components/copy-button/use-copy-links.tsx
+++ b/src/components/copy-button/use-copy-links.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+export const useCopyLinks = () => {
+  const [isCopied, setIsCopied] = useState<boolean>(false);
+
+  useEffect(() => {
+    let timeout: number | null = null;
+    if (isCopied) {
+      timeout = window.setTimeout(() => {
+        setIsCopied(false);
+      }, 1500);
+    }
+    return () => {
+      if (timeout !== null) {
+        window.clearTimeout(timeout);
+      }
+    };
+  }, [isCopied]);
+
+  const handleCopyUrlToClipboard = (input: string | string[]) => {
+    if (input !== null) {
+      navigator.clipboard
+        .writeText(Array.isArray(input) ? input.join("\n") : input)
+        .then(() => {
+          setIsCopied(true);
+        })
+        .catch((err) => {
+          console.error("Failed to copy text: ", err);
+        });
+    }
+  };
+
+  return { isCopied, handleCopyUrlToClipboard };
+};

--- a/src/components/copy-button/use-copy-links.tsx
+++ b/src/components/copy-button/use-copy-links.tsx
@@ -1,28 +1,32 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 export const useCopyLinks = () => {
   const [isCopied, setIsCopied] = useState<boolean>(false);
+  const timeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
-    let timeout: number | null = null;
-    if (isCopied) {
-      timeout = window.setTimeout(() => {
-        setIsCopied(false);
-      }, 1500);
-    }
     return () => {
-      if (timeout !== null) {
-        window.clearTimeout(timeout);
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
       }
     };
-  }, [isCopied]);
+  }, []);
 
   const handleCopyUrlToClipboard = (input: string | string[]) => {
     if (input !== null) {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
       navigator.clipboard
         .writeText(Array.isArray(input) ? input.join("\n") : input)
         .then(() => {
           setIsCopied(true);
+
+          timeoutRef.current = window.setTimeout(() => {
+            setIsCopied(false);
+            timeoutRef.current = null;
+          }, 1500);
         })
         .catch((err) => {
           console.error("Failed to copy text: ", err);

--- a/src/components/create-production/create-production-page.tsx
+++ b/src/components/create-production/create-production-page.tsx
@@ -246,7 +246,10 @@ export const CreateProductionPage = () => {
             The production ID is: {createdProductionId.toString()}
           </ProductionConfirmation>
           {!productionFetchError && production && (
-            <CopyAllLinksButton production={production} flexDirection="row" />
+            <CopyAllLinksButton
+              production={production}
+              className="create-production-page"
+            />
           )}
           {productionFetchError && (
             <FetchErrorMessage>

--- a/src/components/create-production/create-production-page.tsx
+++ b/src/components/create-production/create-production-page.tsx
@@ -27,6 +27,7 @@ import { ResponsiveFormContainer } from "../user-settings/user-settings.tsx";
 import { isMobile } from "../../bowser.ts";
 import { Checkbox } from "../checkbox/checkbox.tsx";
 import { FormValues, useCreateProduction } from "./use-create-production.tsx";
+import { CopyAllLinksButton } from "../copy-button/copy-all-links-button.tsx";
 
 const HeaderWrapper = styled.div`
   display: flex;
@@ -58,16 +59,6 @@ const ProductionConfirmation = styled.div`
   color: #1a1a1a;
 `;
 
-const CopyToClipboardWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
-
-const CopyConfirmation = styled.p`
-  padding-left: 1rem;
-`;
-
 const FetchErrorMessage = styled.div`
   background: ${errorColour};
   color: ${darkText};
@@ -83,7 +74,6 @@ export const CreateProductionPage = () => {
   const [, dispatch] = useGlobalState();
   const [createNewProduction, setCreateNewProduction] =
     useState<FormValues | null>(null);
-  const [copiedUrl, setCopiedUrl] = useState<boolean>(false);
   const {
     formState: { errors },
     control,
@@ -132,34 +122,6 @@ export const CreateProductionPage = () => {
       });
     }
   }, [createdProductionId, dispatch, reset]);
-
-  useEffect(() => {
-    let timeout: number | null = null;
-    if (copiedUrl) {
-      timeout = window.setTimeout(() => {
-        setCopiedUrl(false);
-      }, 1500);
-    }
-    return () => {
-      if (timeout !== null) {
-        window.clearTimeout(timeout);
-      }
-    };
-  }, [copiedUrl]);
-
-  const handleCopyProdUrlsToClipboard = (input: string[]) => {
-    if (input !== null) {
-      navigator.clipboard
-        .writeText(input.join("\n"))
-        .then(() => {
-          setCopiedUrl(true);
-          console.log("Text copied to clipboard");
-        })
-        .catch((err) => {
-          console.error("Failed to copy text: ", err);
-        });
-    }
-  };
 
   return (
     <ResponsiveFormContainer className={isMobile ? "" : "desktop"}>
@@ -284,22 +246,7 @@ export const CreateProductionPage = () => {
             The production ID is: {createdProductionId.toString()}
           </ProductionConfirmation>
           {!productionFetchError && production && (
-            <CopyToClipboardWrapper>
-              <PrimaryButton
-                type="button"
-                onClick={() =>
-                  handleCopyProdUrlsToClipboard(
-                    production.lines.map((item) => {
-                      return ` ${item.name}: ${window.location.origin}/production-calls/production/${production.productionId}/line/${item.id}`;
-                    })
-                  )
-                }
-                disabled={copiedUrl}
-              >
-                Copy Links
-              </PrimaryButton>
-              {copiedUrl && <CopyConfirmation>Copied</CopyConfirmation>}
-            </CopyToClipboardWrapper>
+            <CopyAllLinksButton production={production} flexDirection="row" />
           )}
           {productionFetchError && (
             <FetchErrorMessage>

--- a/src/components/production-line/share-line-link-modal.tsx
+++ b/src/components/production-line/share-line-link-modal.tsx
@@ -92,7 +92,7 @@ export const ShareLineLinkModal = ({
         </ModalTextItalic>
         <Wrapper>
           <FormInput value={url} readOnly />
-          <CopyButton url={url} buttonSize="4rem" marginLeft="1rem" />
+          <CopyButton url={url} className="share-line-link-modal" />
         </Wrapper>
         <RefreshButtonWrapper>
           <StyledRefreshBtn onClick={onRefresh}>

--- a/src/components/production-line/share-line-link-modal.tsx
+++ b/src/components/production-line/share-line-link-modal.tsx
@@ -1,9 +1,10 @@
 import styled from "@emotion/styled";
-import { useEffect, useRef, useState } from "react";
-import { CheckIcon, CopyIcon, RefreshIcon } from "../../assets/icons/icon";
+import { useEffect, useRef } from "react";
+import { RefreshIcon } from "../../assets/icons/icon";
 import { FormInput } from "../landing-page/form-elements";
 import { Modal } from "../modal/modal";
 import { StyledRefreshBtn } from "../reload-devices-button.tsx/reload-devices-button";
+import { CopyButton } from "../copy-button/copy-button";
 
 type TShareLineLinkModalProps = {
   url: string;
@@ -16,35 +17,6 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-`;
-
-const IconWrapper = styled.div<{ isCopied: boolean }>`
-  width: 4rem;
-  height: 4rem;
-  margin-left: 1rem;
-  display: flex;
-  padding: 0.5rem;
-  border-radius: 0.5rem;
-  transition:
-    transform 0.1s ease,
-    background 0.2s ease;
-
-  ${({ isCopied }) =>
-    !isCopied &&
-    `
-    &:active {
-    transform: scale(0.95);
-    background: rgba(0, 0, 0, 0.4);
-  }
-  `}
-
-  &:hover {
-    background: rgba(0, 0, 0, 0.3);
-  }
-
-  svg {
-    fill: #59cbe8;
-  }
 `;
 
 const ModalHeader = styled.h1`
@@ -88,7 +60,6 @@ export const ShareLineLinkModal = ({
   onRefresh,
   onClose,
 }: TShareLineLinkModalProps) => {
-  const [isCopied, setIsCopied] = useState<boolean>(false);
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -104,29 +75,6 @@ export const ShareLineLinkModal = ({
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [onClose]);
-
-  useEffect(() => {
-    if (isCopied) {
-      const timeout = setTimeout(() => {
-        setIsCopied(false);
-      }, 1500);
-      return () => clearTimeout(timeout);
-    }
-    return undefined;
-  }, [isCopied]);
-
-  const handleCopyUrlToClipboard = (input: string) => {
-    if (input !== null) {
-      navigator.clipboard
-        .writeText(input)
-        .then(() => {
-          setIsCopied(true);
-        })
-        .catch((err) => {
-          console.error("Failed to copy text: ", err);
-        });
-    }
-  };
 
   return (
     <Modal onClose={onClose}>
@@ -144,15 +92,7 @@ export const ShareLineLinkModal = ({
         </ModalTextItalic>
         <Wrapper>
           <FormInput value={url} readOnly />
-          <IconWrapper
-            isCopied={isCopied}
-            onClick={() => {
-              if (isCopied) return;
-              handleCopyUrlToClipboard(url);
-            }}
-          >
-            {isCopied ? <CheckIcon /> : <CopyIcon />}
-          </IconWrapper>
+          <CopyButton url={url} buttonSize="4rem" marginLeft="1rem" />
         </Wrapper>
         <RefreshButtonWrapper>
           <StyledRefreshBtn onClick={onRefresh}>

--- a/src/components/production-list/manage-production-buttons.tsx
+++ b/src/components/production-list/manage-production-buttons.tsx
@@ -26,6 +26,7 @@ import {
   RemoveIconWrapper,
   SpinnerWrapper,
 } from "./production-list-components";
+import { CopyAllLinksButton } from "../copy-button/copy-all-links-button";
 
 interface ManageProductionButtonsProps {
   production: TBasicProductionResponse;
@@ -144,6 +145,7 @@ export const ManageProductionButtons: FC<ManageProductionButtonsProps> = (
           )}
         </DeleteButton>
       </ManageButtons>
+      <CopyAllLinksButton production={production} flexDirection="row-reverse" />
       {addLineOpen && (
         <AddLineSectionForm>
           <FormLabel>

--- a/src/components/production-list/manage-production-buttons.tsx
+++ b/src/components/production-list/manage-production-buttons.tsx
@@ -145,7 +145,10 @@ export const ManageProductionButtons: FC<ManageProductionButtonsProps> = (
           )}
         </DeleteButton>
       </ManageButtons>
-      <CopyAllLinksButton production={production} flexDirection="row-reverse" />
+      <CopyAllLinksButton
+        production={production}
+        className="manage-production-page"
+      />
       {addLineOpen && (
         <AddLineSectionForm>
           <FormLabel>

--- a/src/components/production-list/production-list-components.ts
+++ b/src/components/production-list/production-list-components.ts
@@ -167,7 +167,7 @@ export const DeleteButton = styled(SecondaryButton)`
 export const ManageButtons = styled.div`
   display: flex;
   justify-content: flex-end;
-  margin-top: 1rem;
+  margin: 1rem 0 1rem 0;
 `;
 
 export const AddLineSectionForm = styled.form`

--- a/src/components/production-list/production-list-item.tsx
+++ b/src/components/production-list/production-list-item.tsx
@@ -199,8 +199,7 @@ export const ProductionsListItem = ({
                   {managementMode && (
                     <CopyButton
                       url={`${window.location.origin}/production-calls/production/${production.productionId}/line/${l.id}`}
-                      buttonSize="3rem"
-                      marginLeft="0"
+                      className="production-list-item"
                     />
                   )}
                 </LineBlockTitleWrapper>

--- a/src/components/production-list/production-list-item.tsx
+++ b/src/components/production-list/production-list-item.tsx
@@ -42,6 +42,7 @@ import {
   ProductionName,
   SpinnerWrapper,
 } from "./production-list-components";
+import { CopyButton } from "../copy-button/copy-button";
 
 type ProductionsListItemProps = {
   production: TBasicProductionResponse;
@@ -194,6 +195,13 @@ export const ProductionsListItem = ({
                         <ChevronDownIcon />
                       )}
                     </ParticipantExpandBtn>
+                  )}
+                  {managementMode && (
+                    <CopyButton
+                      url={`${window.location.origin}/production-calls/production/${production.productionId}/line/${l.id}`}
+                      buttonSize="3rem"
+                      marginLeft="0"
+                    />
                   )}
                 </LineBlockTitleWrapper>
                 <LineBlockParticipants>


### PR DESCRIPTION
Moved existing copy-functionality into reusable components and made logic into reusable hook. Updated the copy-button to show icon instead of text that reads "copied" 

## Updated button:
<img height="300" alt="Screenshot 2025-04-01 at 13 29 08" src="https://github.com/user-attachments/assets/dfece929-04c1-45c6-91b1-a27b63ac6c9e" />
<img height="300" alt="Screenshot 2025-04-01 at 13 29 12" src="https://github.com/user-attachments/assets/aa514c1a-976b-4752-86c8-0e203100e41d" />

## New button:
<img height="500" alt="Screenshot 2025-04-01 at 13 25 17" src="https://github.com/user-attachments/assets/d3dbbb63-1982-4b3c-a2ed-2ec1b16b582b" />
<img height="500" alt="Screenshot 2025-04-01 at 13 25 27" src="https://github.com/user-attachments/assets/ab04ddab-b842-4e60-a789-72859bcfed8a" />
<img height="500" alt="Screenshot 2025-04-01 at 13 25 34" src="https://github.com/user-attachments/assets/8d1014c4-6816-4f66-af78-adc749282242" />



