### PR TITLE
feat: refresh site by top-scroll disabled

### DIFF
--- a/src/components/calls-page/calls-page.tsx
+++ b/src/components/calls-page/calls-page.tsx
@@ -14,6 +14,7 @@ import { ProductionLine } from "../production-line/production-line";
 import { PageHeader } from "../page-layout/page-header";
 import { isMobile } from "../../bowser";
 import { useAudioCue } from "../production-line/use-audio-cue";
+import { usePreventPullToRefresh } from "./use-prevent-pull-to-refresh";
 
 const Container = styled.div`
   display: flex;
@@ -89,6 +90,8 @@ export const CallsPage = () => {
       callState.joinProductionOptions?.lineUsedForProgramOutput &&
       !callState.joinProductionOptions.isProgramUser
   );
+
+  usePreventPullToRefresh();
 
   useEffect(() => {
     if (isProgramOutputAdded) {

--- a/src/components/calls-page/use-prevent-pull-to-refresh.tsx
+++ b/src/components/calls-page/use-prevent-pull-to-refresh.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+
+export const usePreventPullToRefresh = () => {
+  useEffect(() => {
+    let touchStartY = 0;
+    let isPullingDown = false;
+
+    const handleTouchStart = (event: TouchEvent) => {
+      touchStartY = event.touches[0].clientY;
+      isPullingDown = window.scrollY === 0; // Detect if at the top
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (isPullingDown && event.touches[0].clientY > touchStartY) {
+        event.preventDefault();
+      }
+    };
+
+    const handleTouchEnd = () => {
+      isPullingDown = false;
+    };
+
+    document.addEventListener("touchstart", handleTouchStart, {
+      passive: true,
+    });
+    document.addEventListener("touchmove", handleTouchMove, { passive: false });
+    document.addEventListener("touchend", handleTouchEnd);
+
+    return () => {
+      document.removeEventListener("touchstart", handleTouchStart);
+      document.removeEventListener("touchmove", handleTouchMove);
+      document.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, []);
+
+  return null;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -157,6 +157,11 @@ html {
   height: 100%;
 }
 
+html,
+body {
+  overscroll-behavior: contain;
+}
+
 *,
 *:before,
 *:after {


### PR DESCRIPTION
Added block that the built in top-scroll refresh is disabled on entire site, to prevent users from being accidentally disconnected from calls.