### PR TITLE
fix: solved width-issues and mobile-issues on call-view

### DIFF
--- a/src/components/generic-components.ts
+++ b/src/components/generic-components.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { FormContainer } from "./landing-page/form-elements";
+import { isMobile } from "../bowser";
 
 export const FlexContainer = styled.div`
   display: flex;
@@ -24,6 +25,9 @@ export const ResponsiveFormContainer = styled(FormContainer)`
   &.calls-page {
     margin: 0;
     padding: 2rem;
+    flex: 0 0 calc(25% - 2rem);
+    ${isMobile ? `flex-grow: 1;` : `flex-grow: 0;`}
+    min-width: 30rem;
   }
 `;
 

--- a/src/components/production-line/call-header.tsx
+++ b/src/components/production-line/call-header.tsx
@@ -34,9 +34,10 @@ export const CallHeaderComponent = ({
     line && line.name.length > 40 ? `${line.name.slice(0, 40)}...` : line?.name;
 
   return (
-    <CallHeader onClick={setOpen}>
+    <CallHeader open={open} onClick={setOpen}>
       <HeaderTexts
         open={open}
+        isProgramOutputLine={line?.programOutputLine || false}
         className={(line?.participants.length || 0) > 0 ? "active" : ""}
       >
         {!open && line?.programOutputLine && (
@@ -55,7 +56,7 @@ export const CallHeaderComponent = ({
         <ParticipantCount>{line?.participants.length}</ParticipantCount>
       </HeaderTexts>
       {line?.programOutputLine && open && (
-        <AudioFeedIcon open>
+        <AudioFeedIcon open={open}>
           <TVIcon />
           Audio feed
         </AudioFeedIcon>

--- a/src/components/production-line/call-header.tsx
+++ b/src/components/production-line/call-header.tsx
@@ -10,6 +10,7 @@ import {
   ParticipantCount,
   HeaderIcon,
   Id,
+  ParticipantCountWrapper,
 } from "../production-list/production-list-components";
 import { AudioFeedIcon, CallHeader } from "./production-line-components";
 import { TLine, TProduction } from "./types";
@@ -48,12 +49,16 @@ export const CallHeaderComponent = ({
         <ProductionName
           title={`${production?.name} (id: ${production?.productionId}) / ${line?.name}`}
         >
-          {`${truncatedProductionName}`}
-          <Id>{`(id: ${production?.productionId})`}</Id>
-          {`/ ${truncatedLineName}`}
+          <span className="production-name-container">
+            {`${truncatedProductionName}`}
+            <Id>{`(id: ${production?.productionId})`}</Id>
+            {`/ ${truncatedLineName}`}
+          </span>
         </ProductionName>
-        <UsersIcon />
-        <ParticipantCount>{line?.participants.length}</ParticipantCount>
+        <ParticipantCountWrapper>
+          <UsersIcon />
+          <ParticipantCount>{line?.participants.length}</ParticipantCount>
+        </ParticipantCountWrapper>
       </HeaderTexts>
       {line?.programOutputLine && open && (
         <AudioFeedIcon open={open}>

--- a/src/components/production-line/production-line-components.ts
+++ b/src/components/production-line/production-line-components.ts
@@ -5,6 +5,7 @@ import {
   HeaderWrapper,
   ProductionItemWrapper,
 } from "../production-list/production-list-components";
+import { isMobile } from "../../bowser";
 
 export const CallInfo = styled.div`
   display: flex;
@@ -140,7 +141,9 @@ export const CallWrapper = styled.div<{ isSomeoneSpeaking: boolean }>`
   align-items: center;
   flex-direction: column;
   margin: 0 0 2rem 0;
-  min-width: 20rem;
+  flex: 0 0 calc(25% - 2rem);
+  ${isMobile ? `flex-grow: 1;` : `flex-grow: 0;`}
+  min-width: 30rem;
   background-color: transparent;
   border-radius: 0.5rem;
   animation: ${({ isSomeoneSpeaking }) =>
@@ -163,7 +166,7 @@ export const CallContainer = styled(ProductionItemWrapper)<{
   isProgramLine?: boolean;
 }>`
   margin: 0;
-  min-width: 30rem;
+  width: 100%;
   display: flex;
   flex-direction: column;
 
@@ -173,6 +176,8 @@ export const CallContainer = styled(ProductionItemWrapper)<{
 
 export const CallHeader = styled(HeaderWrapper)`
   position: relative;
+  margin-bottom: ${({ open }: { open: boolean }) =>
+    open && isMobile ? "2rem" : ""};
 `;
 
 export const MinifiedControls = styled.div`

--- a/src/components/production-line/production-line-components.ts
+++ b/src/components/production-line/production-line-components.ts
@@ -5,7 +5,7 @@ import {
   HeaderWrapper,
   ProductionItemWrapper,
 } from "../production-list/production-list-components";
-import { isMobile } from "../../bowser";
+import { isIpad, isMobile } from "../../bowser";
 
 export const CallInfo = styled.div`
   display: flex;
@@ -177,7 +177,7 @@ export const CallContainer = styled(ProductionItemWrapper)<{
 export const CallHeader = styled(HeaderWrapper)`
   position: relative;
   margin-bottom: ${({ open }: { open: boolean }) =>
-    open && isMobile ? "2rem" : ""};
+    open && (isMobile || isIpad) ? "2rem" : ""};
 `;
 
 export const MinifiedControls = styled.div`

--- a/src/components/production-list/production-list-components.ts
+++ b/src/components/production-list/production-list-components.ts
@@ -17,16 +17,27 @@ export const ProductionItemWrapper = styled.div`
 `;
 
 export const ProductionName = styled.div`
-  display: flex;
   font-size: 1.4rem;
   font-weight: bold;
   margin-right: 1rem;
   max-width: 30rem;
-  word-break: break-word;
+  min-width: 20rem;
+
+  .production-name-container {
+    display: inline-block;
+    width: 100%;
+  }
 `;
 
-export const Id = styled.p`
-  font-weight: normal;
+export const Id = styled.span`
+  display: inline;
+  margin: 0 0.2rem;
+`;
+
+export const ParticipantCountWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
 `;
 
 export const ParticipantCount = styled.div`
@@ -43,7 +54,9 @@ export const HeaderWrapper = styled.div`
 `;
 
 export const HeaderTexts = styled.div`
+  width: 100%;
   display: flex;
+  justify-content: space-between;
   align-items: center;
   margin-left: ${({
     open,

--- a/src/components/production-list/production-list-components.ts
+++ b/src/components/production-list/production-list-components.ts
@@ -45,7 +45,13 @@ export const HeaderWrapper = styled.div`
 export const HeaderTexts = styled.div`
   display: flex;
   align-items: center;
-  margin-left: ${({ open }: { open: boolean }) => (open ? "0" : "1.5rem")};
+  margin-left: ${({
+    open,
+    isProgramOutputLine,
+  }: {
+    open: boolean;
+    isProgramOutputLine: boolean;
+  }) => (!open && isProgramOutputLine ? "1.5rem" : "0")};
 
   svg {
     height: 1.5rem;

--- a/src/components/production-list/production-list-item.tsx
+++ b/src/components/production-list/production-list-item.tsx
@@ -117,6 +117,7 @@ export const ProductionsListItem = ({
       <HeaderWrapper onClick={() => setOpen(!open)}>
         <HeaderTexts
           open={open}
+          isProgramOutputLine={false}
           className={totalParticipants > 0 ? "active" : ""}
         >
           <ProductionName title={production.name}>

--- a/src/components/user-settings-form/user-settings-form.tsx
+++ b/src/components/user-settings-form/user-settings-form.tsx
@@ -307,7 +307,9 @@ export const UserSettingsForm = ({
         </>
       )}
       <ButtonWrapper>
-        <ReloadDevicesButton />
+        {(isFirstConnection || isSupportedBrowser || isSettingsConfig) && (
+          <ReloadDevicesButton />
+        )}
         <PrimaryButton
           type="button"
           disabled={isJoinProduction ? !isValid : false}


### PR DESCRIPTION
### Wider calls on both desktop and mobile:

<img width="1726" alt="Screenshot 2025-04-15 at 13 47 36" src="https://github.com/user-attachments/assets/52453586-ac4a-4555-b949-a4117c07c9e2" />

### Before fix:
Only this slim look on chrome, on firefox the look is the same as with the new fix

<img width="1725" alt="Screenshot 2025-04-15 at 13 53 46" src="https://github.com/user-attachments/assets/34eafc0e-0678-439e-9ce2-a004d259f8f5" />

### Mobile fix:
<img width="300" alt="Screenshot 2025-04-15 at 13 48 26" src="https://github.com/user-attachments/assets/70841b55-3076-4b1d-acc2-c5e1c2ba1df1" /><img width="300" alt="Screenshot 2025-04-15 at 13 48 14" src="https://github.com/user-attachments/assets/85b14503-755b-4301-b44a-4bdacc31798d" />

### Before fix:
<img width="300" alt="Screenshot 2025-04-15 at 13 52 29" src="https://github.com/user-attachments/assets/3bdff51e-e7f8-4b5e-93d3-a218e6553ae2" />

### Adjusted width on adding additional call on callspage and removed reload devices-button when not supported
<img width="1717" alt="Screenshot 2025-04-15 at 14 25 00" src="https://github.com/user-attachments/assets/97abc008-f140-48c9-b488-d2074023a181" />

<img width="300" alt="Screenshot 2025-04-15 at 14 24 39" src="https://github.com/user-attachments/assets/be7bebbe-e5d6-4cc9-a1e0-6c0f9bc13848" />
