### PR TITLE
fix: updated the confirmation text on leave-call-modals

### DIFF
--- a/src/components/calls-page/calls-page.tsx
+++ b/src/components/calls-page/calls-page.tsx
@@ -151,6 +151,7 @@ export const CallsPage = () => {
           <ConfirmationModal
             title="Confirm"
             description="Are you sure you want to leave all calls?"
+            confirmationText="This will leave all calls and return to the home page."
             onCancel={() => setConfirmExitModalOpen(false)}
             onConfirm={runExitAllCalls}
           />

--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -556,7 +556,7 @@ export const ProductionLine = ({
                           {confirmExitModalOpen && (
                             <ConfirmationModal
                               title="Confirm"
-                              description="Are you sure you want to leave all calls?"
+                              description={`Are you sure you want to leave ${line?.name}?`}
                               onCancel={() => setConfirmExitModalOpen(false)}
                               onConfirm={exit}
                             />


### PR DESCRIPTION

Updated modal text to refer to singular call when using the "leave call"-button. Added line-name to modal as well.
<img width="1186" alt="Screenshot 2025-04-22 at 12 09 31" src="https://github.com/user-attachments/assets/6b9803f1-ebbb-48fe-b3f1-096fc91452af" />

Added confirmation-text to "back button" so it looks the same as when pressing the home-area
<img width="512" alt="Screenshot 2025-04-22 at 12 09 44" src="https://github.com/user-attachments/assets/118861b1-1093-4aff-bdea-d09ceca69cc3" />
