### PR TITLE
feat: added a delay to the refresh-link buttons

### DIFF
--- a/src/components/copy-button/copy-all-links-button.tsx
+++ b/src/components/copy-button/copy-all-links-button.tsx
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled";
 import { PrimaryButton } from "../landing-page/form-elements";
 import { useCopyLinks } from "./use-copy-links";
 import { TProduction } from "../production-line/types";
@@ -10,6 +11,12 @@ import {
   NoteTextItalic,
   NoteWrapper,
 } from "./copy-components";
+import { Spinner } from "../loader/loader";
+
+const CopyButton = styled(PrimaryButton)`
+  min-width: 12rem;
+  min-height: 4.5rem;
+`;
 
 export const CopyAllLinksButton = ({
   production,
@@ -44,9 +51,9 @@ export const CopyAllLinksButton = ({
         </NoteTextItalic>
       </NoteWrapper>
       <ButtonWrapper className={className}>
-        <PrimaryButton type="button" onClick={handleCopy} disabled={isCopied}>
-          Copy Links
-        </PrimaryButton>
+        <CopyButton type="button" onClick={handleCopy} disabled={isCopied}>
+          {isCopied ? <Spinner className="copy-button" /> : "Copy Links"}
+        </CopyButton>
         {isCopied && <CheckIcon />}
       </ButtonWrapper>
     </CopyToClipboardWrapper>

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -47,6 +47,11 @@ const Loading = styled.div`
     width: 2rem;
   }
 
+  &.copy-button {
+    height: 2rem;
+    width: 2rem;
+  }
+
   @keyframes spin {
     0% {
       transform: rotate(0deg);

--- a/src/components/production-line/share-line-link-modal.tsx
+++ b/src/components/production-line/share-line-link-modal.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FormInput } from "../landing-page/form-elements";
 import { Modal } from "../modal/modal";
 import { CopyButton } from "../copy-button/copy-button";
@@ -55,6 +55,7 @@ export const ShareLineLinkModal = ({
   onClose,
 }: TShareLineLinkModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -69,6 +70,14 @@ export const ShareLineLinkModal = ({
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [onClose]);
+
+  const handleRefresh = async () => {
+    setIsLoading(true);
+    onRefresh();
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 1000);
+  };
 
   return (
     <Modal onClose={onClose}>
@@ -85,10 +94,14 @@ export const ShareLineLinkModal = ({
           Refresh the URL to generate a new one.
         </ModalTextItalic>
         <Wrapper>
-          <FormInput value={url} readOnly />
+          <FormInput value={isLoading ? "Loading..." : url} readOnly />
           <CopyButton url={url} className="share-line-link-modal" />
         </Wrapper>
-        <RefreshButton label="Refresh URL" onRefresh={onRefresh} />
+        <RefreshButton
+          label="Refresh URL"
+          isLoading={isLoading}
+          onRefresh={handleRefresh}
+        />
       </div>
     </Modal>
   );

--- a/src/components/refresh-button/refresh-button.tsx
+++ b/src/components/refresh-button/refresh-button.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { RefreshIcon } from "../../assets/icons/icon";
 import { StyledRefreshBtn } from "../reload-devices-button.tsx/reload-devices-button";
+import { Spinner } from "../loader/loader";
 
 const RefreshButtonWrapper = styled.div`
   display: flex;
@@ -9,16 +10,24 @@ const RefreshButtonWrapper = styled.div`
 
 export const RefreshButton = ({
   label,
+  isLoading,
   onRefresh,
 }: {
   label: string;
+  isLoading: boolean;
   onRefresh: () => void;
 }) => {
   return (
     <RefreshButtonWrapper>
-      <StyledRefreshBtn onClick={onRefresh}>
-        <RefreshIcon />
-        {label}
+      <StyledRefreshBtn onClick={onRefresh} disabled={isLoading}>
+        {isLoading ? (
+          <Spinner className="copy-button" />
+        ) : (
+          <>
+            <RefreshIcon />
+            {label}
+          </>
+        )}
       </StyledRefreshBtn>
     </RefreshButtonWrapper>
   );

--- a/src/components/reload-devices-button.tsx/reload-devices-button.tsx
+++ b/src/components/reload-devices-button.tsx/reload-devices-button.tsx
@@ -14,6 +14,8 @@ export const StyledRefreshBtn = styled(PrimaryButton)`
   margin-right: 1.5rem;
   display: flex;
   align-items: center;
+  min-width: 16rem;
+  min-height: 4.4rem;
 
   svg,
   .refresh-devices {


### PR DESCRIPTION
# Visual delay

To fix the issue with users not experiencing that the refresh-link function is re-generating a new link, a delay is added. In the delay-time a spinner is shown and a information-text is added

## Copy Several Links
A spinner is added

On "Create Production"-page
<img width="500" alt="Screenshot 2025-05-12 at 15 08 29" src="https://github.com/user-attachments/assets/88f28291-237f-46eb-b7f2-3f6a2e714af9" />

On "Manage Production"-page 
<img width="500" alt="Screenshot 2025-05-12 at 15 07 50" src="https://github.com/user-attachments/assets/50ef13a7-4371-4164-8c4d-feb7472298eb" />

## Copy Single Link
A spinner is added and the url are temporarily switched to the text "Loading..."

<img width="500" alt="Screenshot 2025-05-12 at 15 07 31" src="https://github.com/user-attachments/assets/3bd35785-9291-4cd3-baf7-1e1cb94c847a" />

