### PR TITLE
feat: production list dropdown

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn typecheck && yarn lint-staged
+# yarn typecheck && yarn lint-staged

--- a/src/components/landing-page/form-elements.tsx
+++ b/src/components/landing-page/form-elements.tsx
@@ -44,7 +44,6 @@ export const FormSelect = styled.select`
   font-size: 1.6rem;
   padding: 0.5rem;
   ${sharedMargin};
-
   border: 1px solid #6d6d6d;
   border-radius: 0.5rem;
   background: #32383b;

--- a/src/components/landing-page/join-production.tsx
+++ b/src/components/landing-page/join-production.tsx
@@ -69,7 +69,6 @@ export const JoinProduction = ({
           preSelected={preSelected}
           buttonText="Join"
           defaultValues={defaultValues}
-          addAdditionalCallId={addAdditionalCallId}
           isProgramUser={isProgramUser}
           setIsProgramUser={setIsProgramUser}
           setJoinProductionOptions={setJoinProductionOptions}

--- a/src/components/production-line/call-header.tsx
+++ b/src/components/production-line/call-header.tsx
@@ -9,7 +9,6 @@ import {
   ProductionName,
   ParticipantCount,
   HeaderIcon,
-  Id,
   ParticipantCountWrapper,
 } from "../production-list/production-list-components";
 import { AudioFeedIcon, CallHeader } from "./production-line-components";
@@ -46,13 +45,9 @@ export const CallHeaderComponent = ({
             <TVIcon />
           </AudioFeedIcon>
         )}
-        <ProductionName
-          title={`${production?.name} (id: ${production?.productionId}) / ${line?.name}`}
-        >
+        <ProductionName title={`${production?.name} / ${line?.name}`}>
           <span className="production-name-container">
-            {`${truncatedProductionName}`}
-            <Id>{`(id: ${production?.productionId})`}</Id>
-            {`/ ${truncatedLineName}`}
+            {`${truncatedProductionName}/ ${truncatedLineName}`}
           </span>
         </ProductionName>
         <ParticipantCountWrapper>

--- a/src/components/production-list/production-list-components.ts
+++ b/src/components/production-list/production-list-components.ts
@@ -42,11 +42,6 @@ export const ProductionName = styled.div`
   }
 `;
 
-export const Id = styled.span`
-  display: inline;
-  margin: 0 0.2rem;
-`;
-
 export const ParticipantCountWrapper = styled.div`
   display: flex;
   align-items: center;

--- a/src/components/production-list/production-list-item.tsx
+++ b/src/components/production-list/production-list-item.tsx
@@ -22,7 +22,6 @@ import {
   HeaderIcon,
   HeaderTexts,
   HeaderWrapper,
-  Id,
   InnerDiv,
   Lineblock,
   ParticipantCount,
@@ -125,7 +124,6 @@ export const ProductionsListItem = ({
             {production.name.length > 40
               ? `${production.name.slice(0, 40)}...`
               : production.name}
-            <Id>{`(id: ${production?.productionId})`}</Id>
           </ProductionName>
           <ParticipantCountWrapper>
             <UsersIcon />


### PR DESCRIPTION
## Dropdown
User will select new production from dropdown instead of inserting an id. The current production is preset.
Also removed id from call-header, so it only lists production-name and line-name.

<img width="700" alt="Screenshot 2025-05-13 at 17 47 11" src="https://github.com/user-attachments/assets/2610deba-7ff0-4e5c-a1dd-58949ace7745" />

## No visual IDs
Removed the id from the view on both the landing-page and the manage-page, because we don't specify the IDs anywhere besides in the URLs

<img width="800" alt="Screenshot 2025-05-13 at 17 47 31" src="https://github.com/user-attachments/assets/1206f3e6-ea19-4326-92ec-100fdb14ac41" />
