### PR TITLE
fix: added max-width to stop share-button detachment

### DIFF
--- a/src/components/production-line/production-line-components.ts
+++ b/src/components/production-line/production-line-components.ts
@@ -148,6 +148,7 @@ export const CallWrapper = styled.div<{ isSomeoneSpeaking: boolean }>`
   flex: 0 0 calc(25% - 2rem);
   ${isMobile ? `flex-grow: 1;` : `flex-grow: 0;`}
   min-width: 35rem;
+  max-width: 49rem;
   background-color: transparent;
   border-radius: 0.5rem;
   animation: ${({ isSomeoneSpeaking }) =>


### PR DESCRIPTION
Mini-pr to solve this:

<img width="400" alt="Screenshot 2025-05-20 at 14 56 05" src="https://github.com/user-attachments/assets/02f45c19-cbde-4570-a82a-39c0d6ef3b9e" />

## With fix:

<img width="400" alt="Screenshot 2025-05-20 at 14 55 33" src="https://github.com/user-attachments/assets/9669dfaf-fcd7-46e6-9570-eac228e6e533" />