### PR TITLE
fix: ignore 500-error on reauth-fetch fail

### DIFF
--- a/src/hooks/use-reauth.tsx
+++ b/src/hooks/use-reauth.tsx
@@ -16,6 +16,15 @@ export const useSetupTokenRefresh = () => {
     intervalRef.current = setInterval(
       () => {
         API.reauth().catch((error) => {
+          const is500Error =
+            error.message.includes("500") ||
+            error.message.includes("Response Code: 500");
+
+          if (is500Error) {
+            // Don't dispatch 500 errors as they're expected when inital OSC token expires
+            return;
+          }
+
           dispatch({
             type: "ERROR",
             payload: {

--- a/src/hooks/use-reauth.tsx
+++ b/src/hooks/use-reauth.tsx
@@ -16,9 +16,7 @@ export const useSetupTokenRefresh = () => {
     intervalRef.current = setInterval(
       () => {
         API.reauth().catch((error) => {
-          const is500Error =
-            error.message.includes("500") ||
-            error.message.includes("Response Code: 500");
+          const is500Error = error.message.includes("500");
 
           if (is500Error) {
             // Don't dispatch 500 errors as they're expected when inital OSC token expires


### PR DESCRIPTION
Ignore the 500-error on reauth-fetches, due to being expected when osc-token expires.