### PR TITLE
fix: use whip as dominant speaker

### DIFF
--- a/src/components/production-line/use-rtc-connection.ts
+++ b/src/components/production-line/use-rtc-connection.ts
@@ -163,7 +163,6 @@ const establishConnection = ({
       "endpoint" in message &&
       typeof message.endpoint === "string"
     ) {
-      console.log("Dominant Speaker message received or LastN:", message);
       dispatch({
         type: "UPDATE_CALL",
         payload: {
@@ -186,7 +185,6 @@ const establishConnection = ({
       "muteParticipant" in message.payload &&
       typeof message.payload.muteParticipant === "string"
     ) {
-      console.log("Mute message received:", message);
       dispatch({
         type: "UPDATE_CALL",
         payload: {

--- a/src/components/production-line/use-rtc-connection.ts
+++ b/src/components/production-line/use-rtc-connection.ts
@@ -159,7 +159,9 @@ const establishConnection = ({
       message &&
       typeof message === "object" &&
       "type" in message &&
-      (message.type === "DominantSpeaker" || (message.type === "LastN" && Array.isArray((message as any).endpoints))) &&
+      (message.type === "DominantSpeaker" ||
+        (message.type === "LastN" &&
+          Array.isArray((message as any).endpoints))) &&
       "endpoint" in message &&
       typeof message.endpoint === "string"
     ) {


### PR DESCRIPTION
This PR fixes the issue where sometimes, a WHIP stream in a call did not show as the dominant speaker in the call - instead, a normal user in the call showed as the dominant speaker without talking at all.