### PR TITLE
feat: new firefox device warning

### DIFF
--- a/src/assets/icons/icon.tsx
+++ b/src/assets/icons/icon.tsx
@@ -23,6 +23,7 @@ import UserSettings from "./user_settings.svg?react";
 import Users from "./users.svg?react";
 import VolumeOff from "./volume_off.svg?react";
 import VolumeOn from "./volume_on.svg?react";
+import Warning from "./warning.svg?react";
 
 export const MicMuted = () => <MicMute />;
 
@@ -73,3 +74,5 @@ export const CheckIcon = () => <Check />;
 export const SaveIcon = () => <Save />;
 
 export const HelpIcon = () => <Help />;
+
+export const WarningIcon = () => <Warning />;

--- a/src/assets/icons/warning.svg
+++ b/src/assets/icons/warning.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="#e8eaed" viewBox="0 0 24 24">
+  <path d="M12 5.99 19.53 19H4.47L12 5.99M12 2 1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z" />
+</svg>

--- a/src/components/calls-page/connect-to-ws-modal.tsx
+++ b/src/components/calls-page/connect-to-ws-modal.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { HelpIcon } from "../../assets/icons/icon";
 import { PrimaryButton, SecondaryButton } from "../form-elements/form-elements";
 import { Modal } from "../modal/modal";
-import { ToolTip } from "../tool-tip/tool-tip";
+import { ToolTip } from "../tooltip/tooltip";
 
 const ButtonWrapper = styled.div`
   display: flex;

--- a/src/components/calls-page/connect-to-ws-modal.tsx
+++ b/src/components/calls-page/connect-to-ws-modal.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { HelpIcon } from "../../assets/icons/icon";
 import { PrimaryButton, SecondaryButton } from "../form-elements/form-elements";
 import { Modal } from "../modal/modal";
+import { ToolTip } from "../tool-tip/tool-tip";
 
 const ButtonWrapper = styled.div`
   display: flex;
@@ -28,47 +29,6 @@ const ModalHeader = styled.h2`
 
 const ModalText = styled.p`
   margin-bottom: 1rem;
-`;
-
-const IconWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-
-  svg {
-    fill: grey;
-    width: 2.2rem;
-    height: 2.2rem;
-  }
-`;
-
-const TooltipWrapper = styled.div`
-  position: relative;
-  display: inline-block;
-  cursor: pointer;
-
-  &:hover span {
-    opacity: 1;
-    visibility: visible;
-  }
-`;
-
-const TooltipText = styled.span`
-  position: absolute;
-  bottom: 125%;
-  left: 50%;
-  transform: translateX(-50%);
-  background-color: #333;
-  color: #fff;
-  padding: 0.4rem 0.8rem;
-  border-radius: 0.4rem;
-  font-size: 1.2rem;
-  white-space: nowrap;
-  opacity: 0;
-  visibility: hidden;
-  transition: all 0.2s ease;
-  pointer-events: none;
-  z-index: 10;
 `;
 
 const InputGroup = styled.div`
@@ -146,18 +106,15 @@ export const ConnectToWsModal = ({
     <Modal onClose={onClose}>
       <HeaderWrapper>
         <ModalHeader>Connect to Companion WebSocket</ModalHeader>
-        <IconWrapper>
-          <TooltipWrapper>
-            <a
-              href="https://docs.osaas.io/osaas.wiki/User-Guide%3A-Cloud-Intercom.html#controlling-your-calls-with-an-elgato-stream-deck-using-companion"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <HelpIcon />
-            </a>
-            <TooltipText>View user guide</TooltipText>
-          </TooltipWrapper>
-        </IconWrapper>
+        <ToolTip tooltipText="View user guide">
+          <a
+            href="https://docs.osaas.io/osaas.wiki/User-Guide%3A-Cloud-Intercom.html#controlling-your-calls-with-an-elgato-stream-deck-using-companion"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <HelpIcon />
+          </a>
+        </ToolTip>
       </HeaderWrapper>
       <ModalText>
         To connect to the WebSocket server, please enter it&apos;s address:

--- a/src/components/calls-page/connect-to-ws-modal.tsx
+++ b/src/components/calls-page/connect-to-ws-modal.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { HelpIcon } from "../../assets/icons/icon";
 import { PrimaryButton, SecondaryButton } from "../form-elements/form-elements";
 import { Modal } from "../modal/modal";
-import { ToolTip } from "../tooltip/tooltip";
+import { Tooltip } from "../tooltip/tooltip";
 
 const ButtonWrapper = styled.div`
   display: flex;
@@ -106,7 +106,7 @@ export const ConnectToWsModal = ({
     <Modal onClose={onClose}>
       <HeaderWrapper>
         <ModalHeader>Connect to Companion WebSocket</ModalHeader>
-        <ToolTip tooltipText="View user guide">
+        <Tooltip tooltipText="View user guide">
           <a
             href="https://docs.osaas.io/osaas.wiki/User-Guide%3A-Cloud-Intercom.html#controlling-your-calls-with-an-elgato-stream-deck-using-companion"
             target="_blank"
@@ -114,7 +114,7 @@ export const ConnectToWsModal = ({
           >
             <HelpIcon />
           </a>
-        </ToolTip>
+        </Tooltip>
       </HeaderWrapper>
       <ModalText>
         To connect to the WebSocket server, please enter it&apos;s address:

--- a/src/components/form-elements/form-elements.ts
+++ b/src/components/form-elements/form-elements.ts
@@ -247,3 +247,16 @@ export const SecondaryButton = styled(ActionButton)`
     background: rgba(255, 255, 255, 0.8);
   }
 `;
+
+export const SectionTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 3rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+`;
+
+export const DevicesSection = styled.div`
+  position: relative;
+`;

--- a/src/components/production-line/collapsable-section.tsx
+++ b/src/components/production-line/collapsable-section.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { FC, PropsWithChildren, useState } from "react";
 import { ChevronDownIcon, ChevronUpIcon } from "../../assets/icons/icon";
+import { FirefoxWarning } from "./firefox-warning";
 
 const SectionWrapper = styled.div`
   border: 0.2rem #6d6d6d solid;
@@ -15,6 +16,7 @@ const SectionHeader = styled.div`
   align-items: center;
   height: 3rem;
   font-weight: bold;
+  position: relative;
 
   &:hover {
     cursor: pointer;
@@ -56,6 +58,9 @@ export const CollapsableSection: FC<CollapsableSectionProps> = (props) => {
     <SectionWrapper>
       <SectionHeader onClick={() => setOpen(!open)}>
         <SectionTitle>{title}</SectionTitle>
+        {title === "Devices" && open && (
+          <FirefoxWarning type="collapsable-header" />
+        )}
         <SectionCollapser>
           {open ? <ChevronUpIcon /> : <ChevronDownIcon />}
         </SectionCollapser>

--- a/src/components/production-line/firefox-warning.tsx
+++ b/src/components/production-line/firefox-warning.tsx
@@ -1,0 +1,24 @@
+import { ToolTip } from "../tool-tip/tool-tip";
+import { WarningIcon } from "../../assets/icons/icon";
+
+export const FirefoxWarning = ({
+  type,
+}: {
+  type: "collapsable-header" | "firefox-warning";
+}) => {
+  return (
+    <ToolTip
+      tooltipText={
+        <>
+          <p>If a new device has been added Firefox</p>
+          <p>needs the permission to be manually reset.</p>
+          <p>If your device is missing, please</p>
+          <p>remove the permission and reload page.</p>
+        </>
+      }
+      type={type}
+    >
+      <WarningIcon />
+    </ToolTip>
+  );
+};

--- a/src/components/production-line/firefox-warning.tsx
+++ b/src/components/production-line/firefox-warning.tsx
@@ -1,4 +1,4 @@
-import { ToolTip } from "../tooltip/tooltip";
+import { Tooltip } from "../tooltip/tooltip";
 import { WarningIcon } from "../../assets/icons/icon";
 
 export const FirefoxWarning = ({
@@ -7,7 +7,7 @@ export const FirefoxWarning = ({
   type: "collapsable-header" | "firefox-warning";
 }) => {
   return (
-    <ToolTip
+    <Tooltip
       tooltipText={
         <p>
           If a new device has been added Firefox needs the permission to be
@@ -18,6 +18,6 @@ export const FirefoxWarning = ({
       type={type}
     >
       <WarningIcon />
-    </ToolTip>
+    </Tooltip>
   );
 };

--- a/src/components/production-line/firefox-warning.tsx
+++ b/src/components/production-line/firefox-warning.tsx
@@ -1,4 +1,4 @@
-import { ToolTip } from "../tool-tip/tool-tip";
+import { ToolTip } from "../tooltip/tooltip";
 import { WarningIcon } from "../../assets/icons/icon";
 
 export const FirefoxWarning = ({
@@ -9,12 +9,11 @@ export const FirefoxWarning = ({
   return (
     <ToolTip
       tooltipText={
-        <>
-          <p>If a new device has been added Firefox</p>
-          <p>needs the permission to be manually reset.</p>
-          <p>If your device is missing, please</p>
-          <p>remove the permission and reload page.</p>
-        </>
+        <p>
+          If a new device has been added Firefox needs the permission to be
+          manually reset. If your device is missing, please remove the
+          permission and reload page.
+        </p>
       }
       type={type}
     >

--- a/src/components/production-line/select-devices.tsx
+++ b/src/components/production-line/select-devices.tsx
@@ -163,13 +163,6 @@ export const SelectDevices = ({
           )}
         </FormLabel>
       )}
-      {isBrowserFirefox && !isMobile && (
-        <StyledWarningMessage>
-          If a new device has been added Firefox needs the permission to be
-          manually reset. If your device is missing, please remove the
-          permission and reload page.
-        </StyledWarningMessage>
-      )}
       <DeviceButtonWrapper>
         {!(isBrowserFirefox && !isMobile) && <ReloadDevicesButton />}
         <PrimaryButton

--- a/src/components/tool-tip/tool-tip.tsx
+++ b/src/components/tool-tip/tool-tip.tsx
@@ -1,0 +1,87 @@
+import styled from "@emotion/styled";
+
+const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+
+  svg {
+    fill: grey;
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+
+  &.collapsable-header,
+  &.firefox-warning {
+    svg {
+      fill: #ebca6a;
+    }
+  }
+
+  &.collapsable-header {
+    position: absolute;
+    left: 25%;
+  }
+
+  &.firefox-warning {
+    position: absolute;
+    left: 8rem;
+    bottom: 0.2rem;
+  }
+`;
+
+const TooltipWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+
+  &:hover span {
+    opacity: 1;
+    visibility: visible;
+  }
+`;
+
+const TooltipText = styled.span`
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #333;
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.4rem;
+  font-size: 1.2rem;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.2s ease;
+  pointer-events: none;
+  z-index: 10;
+
+  &.collapsable-header,
+  &.firefox-warning {
+    bottom: -9rem;
+    left: 8rem;
+    background-color: #676767;
+    line-height: 1.5;
+  }
+`;
+
+export const ToolTip = ({
+  children,
+  tooltipText,
+  type,
+}: {
+  children: React.ReactNode;
+  tooltipText: string | React.ReactNode;
+  type?: "collapsable-header" | "firefox-warning";
+}) => {
+  return (
+    <IconWrapper className={type}>
+      <TooltipWrapper>
+        {children}
+        <TooltipText className={type}>{tooltipText}</TooltipText>
+      </TooltipWrapper>
+    </IconWrapper>
+  );
+};

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -73,7 +73,7 @@ const TooltipText = styled.span`
   }
 `;
 
-export const ToolTip = ({
+export const Tooltip = ({
   children,
   tooltipText,
   type,

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -15,18 +15,21 @@ const IconWrapper = styled.div`
   &.firefox-warning {
     svg {
       fill: #ebca6a;
+      width: 2rem;
+      height: 2rem;
     }
   }
 
   &.collapsable-header {
     position: absolute;
-    left: 25%;
+    left: 20%;
   }
 
   &.firefox-warning {
     position: absolute;
-    left: 8rem;
-    bottom: 0.2rem;
+    left: 6.5rem;
+    bottom: 0.5rem;
+    width: auto;
   }
 `;
 
@@ -51,7 +54,7 @@ const TooltipText = styled.span`
   padding: 0.4rem 0.8rem;
   border-radius: 0.4rem;
   font-size: 1.2rem;
-  white-space: nowrap;
+  white-space: normal;
   opacity: 0;
   visibility: hidden;
   transition: all 0.2s ease;
@@ -61,9 +64,12 @@ const TooltipText = styled.span`
   &.collapsable-header,
   &.firefox-warning {
     bottom: -9rem;
-    left: 8rem;
+    left: 0;
     background-color: #676767;
     line-height: 1.5;
+    white-space: normal;
+    transform: none;
+    width: 26rem;
   }
 `;
 

--- a/src/components/user-settings-form/user-settings-form.tsx
+++ b/src/components/user-settings-form/user-settings-form.tsx
@@ -7,9 +7,11 @@ import { useSubmitOnEnter } from "../../hooks/use-submit-form-enter-press";
 import { Checkbox } from "../checkbox/checkbox";
 import { ButtonWrapper } from "../generic-components";
 import {
+  DevicesSection,
   FormInput,
   FormSelect,
   PrimaryButton,
+  SectionTitle,
   StyledWarningMessage,
 } from "../form-elements/form-elements";
 import {
@@ -23,6 +25,7 @@ import { ConfirmationModal } from "../verify-decision/confirmation-modal";
 import { FormItem } from "./form-item";
 import { useSubmitForm } from "./use-submit-form";
 import { useFetchProductionList } from "../landing-page/use-fetch-production-list";
+import { FirefoxWarning } from "../production-line/firefox-warning";
 
 type FormValues = TJoinProductionOptions & {
   audiooutput: string;
@@ -188,7 +191,7 @@ export const UserSettingsForm = ({
   });
 
   return (
-    <>
+    <div style={{ minWidth: updateUserSettings ? "40rem" : "" }}>
       {!preSelected && isJoinProduction && (
         <FormItem label="Production Name" errors={errors}>
           <FormSelect
@@ -218,6 +221,38 @@ export const UserSettingsForm = ({
           )}
         </FormItem>
       )}
+      {!preSelected && isJoinProduction && (
+        <FormItem label="Line">
+          <FormSelect
+            // eslint-disable-next-line
+            {...register(`lineId`, {
+              required: "Line id is required",
+              minLength: 1,
+              onChange: (e) => {
+                const selectedLine = production?.lines.find(
+                  (line) => line.id.toString() === e.target.value
+                );
+                setIsProgramOutputLine(!!selectedLine?.programOutputLine);
+              },
+            })}
+            style={{
+              display: production ? "block" : "none",
+            }}
+          >
+            {production &&
+              production.lines.map((line) => (
+                <option key={line.id} value={line.id}>
+                  {line.name || line.id}
+                </option>
+              ))}
+          </FormSelect>
+          {!production && (
+            <StyledWarningMessage>
+              Please enter a production id
+            </StyledWarningMessage>
+          )}
+        </FormItem>
+      )}
       <FormItem label="Username" fieldName="username" errors={errors}>
         <FormInput
           // eslint-disable-next-line
@@ -230,6 +265,10 @@ export const UserSettingsForm = ({
       </FormItem>
       {(isFirstConnection || isSupportedBrowser || isSettingsConfig) && (
         <>
+          <DevicesSection>
+            <SectionTitle>Devices</SectionTitle>
+            {isBrowserFirefox && <FirefoxWarning type="firefox-warning" />}
+          </DevicesSection>
           <FormItem label="Input">
             <FormSelect
               // eslint-disable-next-line
@@ -265,38 +304,6 @@ export const UserSettingsForm = ({
             )}
           </FormItem>
         </>
-      )}
-      {!preSelected && isJoinProduction && (
-        <FormItem label="Line">
-          <FormSelect
-            // eslint-disable-next-line
-            {...register(`lineId`, {
-              required: "Line id is required",
-              minLength: 1,
-              onChange: (e) => {
-                const selectedLine = production?.lines.find(
-                  (line) => line.id.toString() === e.target.value
-                );
-                setIsProgramOutputLine(!!selectedLine?.programOutputLine);
-              },
-            })}
-            style={{
-              display: production ? "block" : "none",
-            }}
-          >
-            {production &&
-              production.lines.map((line) => (
-                <option key={line.id} value={line.id}>
-                  {line.name || line.id}
-                </option>
-              ))}
-          </FormSelect>
-          {!production && (
-            <StyledWarningMessage>
-              Please enter a production id
-            </StyledWarningMessage>
-          )}
-        </FormItem>
       )}
       {isProgramOutputLine && isJoinProduction && (
         <>
@@ -348,6 +355,6 @@ export const UserSettingsForm = ({
           shouldSubmitOnEnter
         />
       )}
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
Made tooltip into a reusable-component and added a firefox-warning-tooltip. Added the tooltip to all places where devices are set, only showing on firefox.

## On hover
The tooltip is then shown on hover:
<div align="center">
<img height="230" alt="Screenshot 2025-08-19 at 13 12 29" src="https://github.com/user-attachments/assets/a4688839-7baa-40b4-8621-35d349e37aa1" />
<img height="230" alt="Screenshot 2025-08-19 at 13 06 49" src="https://github.com/user-attachments/assets/b913a6b6-7316-4121-b53c-e599a7eb0228" />
</div>


## Main settings-page
<img width="1000" height="993" alt="Screenshot 2025-08-19 at 14 05 14" src="https://github.com/user-attachments/assets/feea4207-7291-400a-bc84-411e2768691a" />

## Settings for calls-page
<img width="1000" height="991" alt="Screenshot 2025-08-19 at 14 04 54" src="https://github.com/user-attachments/assets/dfc7c1e8-bb9a-43a2-8fd3-2ee34e41ce44" />

## Device-setup for individual calls
<img width="300" height="765" alt="Screenshot 2025-08-19 at 13 12 21" src="https://github.com/user-attachments/assets/ed7dc2d0-9e7a-4a71-875d-ae18f9a65321" />

## Device-setup for new calls
<img width="300" height="511" alt="Screenshot 2025-08-19 at 13 06 39" src="https://github.com/user-attachments/assets/7e9f0a1b-29ba-4348-9248-682e6c9d9112" />
