### PR TITLE
fix: no red indicator if whip

### DIFF
--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -418,10 +418,15 @@ export const ProductionLine = ({
 
   // TODO detect if browser back button is pressed and run exit();
 
+  const isWhipOnLine = line?.participants.some((p) => p.isWhip);
+
   return (
     <CallWrapper
       isSomeoneSpeaking={
-        !isProgramOutputLine && !isSelfDominantSpeaker && isActiveParticipant
+        !isProgramOutputLine &&
+        !isSelfDominantSpeaker &&
+        isActiveParticipant &&
+        !isWhipOnLine
       }
     >
       {joinProductionOptions &&


### PR DESCRIPTION
Don't show the red pulse on the call if there is a WHIP session on that call.