### PR TITLE
Show block for connecting multiple companions

### DIFF
--- a/src/components/calls-page/connect-to-ws-button.tsx
+++ b/src/components/calls-page/connect-to-ws-button.tsx
@@ -86,11 +86,15 @@ export const ConnectToWSButton = ({
 }: ConnectToWSButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isWSReconnecting, setIsWSReconnecting] = useState(false);
+  const [isConnectionConflict, setConnectionConflict] = useState(false);
   const [{ error, calls }, dispatch] = useGlobalState();
 
   useEffect(() => {
     if (error) {
       setIsWSReconnecting(false);
+      if (error.statusCode === 409) {
+        setConnectionConflict(true);
+      }
     }
   }, [error, setIsWSReconnecting]);
 
@@ -133,6 +137,7 @@ export const ConnectToWSButton = ({
   };
 
   const renderButtonContent = () => {
+    if (isConnectionConflict) return "Already Connected";
     if (isWSConnected) return "Companion";
     if (isWSReconnecting) return "Reconnecting...";
     return "Connect to Companion";

--- a/src/components/calls-page/connect-to-ws-button.tsx
+++ b/src/components/calls-page/connect-to-ws-button.tsx
@@ -19,19 +19,10 @@ const ConnectWebSocketWrapper = styled.div`
 
 const ConnectButton = styled(PrimaryButton)<{
   isConnected: boolean;
-  isConnectionConflict: boolean;
 }>`
-  background: ${({ isConnected, isConnectionConflict }) => {
-    if (isConnectionConflict) return "#f96c6c";
-    if (isConnected) return "#73d16d";
-    return "";
-  }};
+  background: ${({ isConnected }) => (isConnected ? "#73d16d" : "")};
   border: 0.2rem solid
-    ${({ isConnected, isConnectionConflict }) => {
-      if (isConnectionConflict) return "#f96c6c";
-      if (isConnected) return "#73d16d";
-      return "rgba(89, 203, 232, 1)";
-    }};
+    ${({ isConnected }) => (isConnected ? "#73d16d" : "rgba(89, 203, 232, 1)")};
   text-align: center;
   padding: 1rem;
   align-items: center;
@@ -149,6 +140,7 @@ export const ConnectToWSButton = ({
       setConnectionConflict(false);
       setIsWSReconnecting(false);
       wsDisconnect();
+      setIsOpen(true);
       return;
     }
     if (isWSConnected) {
@@ -159,7 +151,6 @@ export const ConnectToWSButton = ({
   };
 
   const renderButtonContent = () => {
-    if (isConnectionConflict) return "Already Connected";
     if (isWSConnected) return "Companion";
     if (isWSReconnecting) return "Reconnecting...";
     return "Connect to Companion";
@@ -168,11 +159,7 @@ export const ConnectToWSButton = ({
   return (
     <ConnectWebSocketWrapper>
       <TooltipWrapper>
-        <ConnectButton
-          isConnected={isWSConnected}
-          isConnectionConflict={isConnectionConflict}
-          onClick={handlePrimaryClick}
-        >
+        <ConnectButton isConnected={isWSConnected} onClick={handlePrimaryClick}>
           {renderButtonContent()}
           {isWSConnected && <CheckIcon />}
           {!isConnectionConflict && isWSReconnecting && (
@@ -180,9 +167,7 @@ export const ConnectToWSButton = ({
           )}
         </ConnectButton>
 
-        {(isWSConnected || isConnectionConflict) && (
-          <TooltipText id="disconnect">Disconnect</TooltipText>
-        )}
+        {isWSConnected && <TooltipText id="disconnect">Disconnect</TooltipText>}
       </TooltipWrapper>
 
       <ConnectToWsModal

--- a/src/hooks/use-websocket.ts
+++ b/src/hooks/use-websocket.ts
@@ -16,6 +16,9 @@ interface UseWebSocketProps {
   onAction: (action: WebSocketAction, index?: number) => void;
   onConnected?: () => void;
   resetLastSentCallsState?: () => void;
+
+  /** NEW: called when server rejects with 409 */
+  onConflict?: (message?: string) => void;
 }
 
 export function useWebSocket({
@@ -23,6 +26,7 @@ export function useWebSocket({
   onAction,
   onConnected,
   resetLastSentCallsState,
+  onConflict,
 }: UseWebSocketProps) {
   const socketRef = useRef<WebSocket | null>(null);
   const [isWSConnected, setIsWSConnected] = useState<boolean>(false);
@@ -48,19 +52,34 @@ export function useWebSocket({
 
       ws.onopen = () => {
         clearTimeout(timeout);
-
+        // Mark connected; if server immediately sends 409 we’ll flip back to false
         setIsWSConnected(true);
         dispatch({ type: "SET_WEBSOCKET", payload: ws });
-
-        if (onConnected) {
-          onConnected();
-        }
+        if (onConnected) onConnected();
       };
 
       ws.onmessage = (event: MessageEvent) => {
         try {
           const data = JSON.parse(event.data);
-          if (data.action) {
+
+          // Handle connection conflict
+          if (data?.type === "error" && data?.statusCode === 409) {
+            // Local UI path
+            if (onConflict) onConflict(data?.message);
+            // Create a real Error so name/message render correctly
+            const err = new Error(data?.message || "Connection conflict");
+            err.statusCode = 409;
+
+            dispatch({
+              type: "ERROR",
+              payload: { error: err },
+            });
+            setIsWSConnected(false);
+            ws.close();
+            return;
+          }
+
+          if (data?.action) {
             onAction(data.action, data.index);
           }
         } catch (e) {
@@ -87,16 +106,14 @@ export function useWebSocket({
 
       socketRef.current = ws;
     },
-    [onAction, dispatch, onConnected]
+    [onAction, dispatch, onConnected, onConflict]
   );
 
   const wsDisconnect = () => {
     socketRef.current?.close();
     socketRef.current = null;
 
-    if (resetLastSentCallsState) {
-      resetLastSentCallsState();
-    }
+    if (resetLastSentCallsState) resetLastSentCallsState();
 
     setIsWSConnected(false);
     dispatch({ type: "SET_WEBSOCKET", payload: null });
@@ -105,15 +122,11 @@ export function useWebSocket({
   useEffect(() => {
     return () => {
       if (socketRef.current) {
-        socketRef.current?.close();
+        socketRef.current.close();
         socketRef.current = null;
       }
     };
   }, []);
 
-  return {
-    wsDisconnect,
-    wsConnect,
-    isWSConnected,
-  };
+  return { wsDisconnect, wsConnect, isWSConnected };
 }

--- a/src/hooks/use-websocket.ts
+++ b/src/hooks/use-websocket.ts
@@ -61,7 +61,6 @@ export function useWebSocket({
           if (data?.type === "error" && data?.statusCode === 409) {
             if (onConflict) onConflict(data?.message);
             const err = new Error(data?.message || "Connection conflict");
-            err.statusCode = 409;
             dispatch({
               type: "ERROR",
               payload: { error: err },


### PR DESCRIPTION
[Related issue](https://github.com/Eyevinn/intercom-frontend/issues/402)
This PR needs to be merged **_before_** the [PR made for companion](https://github.com/Eyevinn/companion-module-eyevinn-intercom/pull/5) for easy and error-free implementation.

**Background:**
As of now, if one is to connect the same companion on multiple browsers, intercom allows for it and causes confusion for the companion. This is not good, since the companion now works for both browsers, and causes the companion to not know exactly which production and line it is in.

**Solution:**
This PR ensures that if one is to connect a companion on multiple browsers, an error shows up, stating that the companion is already connected on another browser and that the user should disconnect before reconnecting. This will only work however when the [PR for companion](https://github.com/Eyevinn/companion-module-eyevinn-intercom/pull/5) is also merged and deployed, but this PR must be merged first. These changes on their own will work as intercom already does, only that it now allows and can handle connection conflicts, that the companion module repository can send via error statuscode 409 once that PR is merged. 

If this PR is merged first, and the companion module second, connecting a companion to multiple browsers will look like this:
**Before:** 
<img width="491" height="549" alt="image" src="https://github.com/user-attachments/assets/8d8b16ce-5418-4fc9-84b9-9c38e7e1b37e" />
<img width="482" height="545" alt="image" src="https://github.com/user-attachments/assets/e4a539a8-68aa-47da-ac72-aa7cf4e6a80c" />

**After:**
<img width="486" height="540" alt="image" src="https://github.com/user-attachments/assets/7e5afb29-77bc-4afe-9452-305e0c56452b" />
<img width="486" height="612" alt="image" src="https://github.com/user-attachments/assets/9588b7fc-4fd3-4051-af0a-97109eb58066" />
