### PR TITLE
fix: stop heartbeat on 401

### DIFF
--- a/src/components/production-line/use-heartbeat.ts
+++ b/src/components/production-line/use-heartbeat.ts
@@ -12,8 +12,9 @@ export const useHeartbeat = ({ sessionId }: TProps) => {
     const interval = window.setInterval(() => {
       API.heartbeat({ sessionId }).catch((error) => {
         logger.red(error);
-
-        const is401Error = error.message.includes("401");
+        const is401Error =
+          error.message.includes("401") ||
+          error.message.includes("Unauthorized");
         if (is401Error) {
           window.clearInterval(interval);
         }


### PR DESCRIPTION
**Background**
Ever since whip auth key was implemented, 401s are returned to the frontend whenever a whip key is incorrect. However, heartbeats for sessions where user received 401 error code (being unauthorised) were still sent every 10 seconds. Meaning, even though a user is deemed unauthorised by the manager, the session was not cleared and thus generating unnecessary traffic. 

**Solution**
Check if error message contains `401` or `Unauthorized`, if so, run ` window.clearInterval(interval);`


We tried to test our solution manually but we are not 100% sure this works as intended. We tried mocking a 401 and handling that, and also by manually forcing a 401 by trying to join a call as a whip user with wrong whip auth key, but cannot see whether the heartbeat for the whip user actually stops or not.

Our mocking of 401
<img width="517" height="300" alt="image" src="https://github.com/user-attachments/assets/5c254d78-e7d9-42f1-bd55-1a5baa9099ad" />

Before and after 401 was mocked, heartbeat stops and is not called every 10s
<img width="1038" height="743" alt="image" src="https://github.com/user-attachments/assets/79586f5e-d888-415b-9e93-9579f7541310" />
