### PR TITLE
fix: send isSomeoneSpeaking indicator over ws

### DIFF
--- a/src/components/production-line/production-line.tsx
+++ b/src/components/production-line/production-line.tsx
@@ -148,6 +148,12 @@ export const ProductionLine = ({
   );
 
   const isSelfDominantSpeaker = lineParticipant === dominantSpeaker;
+  const isWhipOnLine = line?.participants.some((p) => p.isWhip);
+  const isSomeoneSpeaking =
+    !isProgramOutputLine &&
+    !isSelfDominantSpeaker &&
+    isActiveParticipant &&
+    !isWhipOnLine;
 
   const { production, error: fetchProductionError } = useFetchProduction(
     joinProductionOptions
@@ -187,6 +193,7 @@ export const ProductionLine = ({
           isProgramOutputLine ||
           false,
         isProgramUser: joinProductionOptions?.isProgramUser || false,
+        isSomeoneSpeaking: isSomeoneSpeaking || false,
       },
       isSettingGlobalMute
     );
@@ -202,6 +209,7 @@ export const ProductionLine = ({
     registerCallList,
     isProgramOutputLine,
     isProgramUser,
+    isSomeoneSpeaking,
   ]);
 
   useEffect(() => {
@@ -416,8 +424,6 @@ export const ProductionLine = ({
   };
 
   // TODO detect if browser back button is pressed and run exit();
-
-  const isWhipOnLine = line?.participants.some((p) => p.isWhip);
 
   return (
     <CallWrapper

--- a/src/hooks/use-call-list.ts
+++ b/src/hooks/use-call-list.ts
@@ -10,6 +10,7 @@ export type CallData = {
   productionName: string;
   isProgramOutputLine: boolean;
   isProgramUser: boolean;
+  isSomeoneSpeaking: boolean;
 };
 
 type UseCallListProps = {
@@ -98,7 +99,8 @@ export function useCallList({
         (prev.isOutputMuted !== data.isOutputMuted &&
           ((data.isProgramOutputLine && !data.isProgramUser) ||
             !data.isProgramOutputLine)) ||
-        prev.volume !== data.volume;
+        prev.volume !== data.volume ||
+        prev.isSomeoneSpeaking !== data.isSomeoneSpeaking;
 
       if (!hasChanged) return;
 


### PR DESCRIPTION
Adds the isSomeoneSpeaking variable to the CallData payload that is sent over WebSocket to the Bitfocus Companion module. This is so that the speaking indication can be added to streamdecks connected to Companion.