### PR TITLE
chore: added timer to create production message

### DIFF
--- a/src/components/create-production/create-production-page.tsx
+++ b/src/components/create-production/create-production-page.tsx
@@ -36,6 +36,7 @@ export const CreateProductionPage = () => {
   const [, dispatch] = useGlobalState();
   const [createNewProduction, setCreateNewProduction] =
     useState<FormValues | null>(null);
+  const [showConfirmation, setShowConfirmation] = useState(false);
   const {
     formState: { errors },
     control,
@@ -127,6 +128,18 @@ export const CreateProductionPage = () => {
       });
     }
   }, [data?.productionId, dispatch, reset]);
+
+  // Auto-hide confirmation after a short delay
+  useEffect(() => {
+    if (!success || !data?.name) {
+      setShowConfirmation(false);
+      return;
+    }
+
+    setShowConfirmation(true);
+    const id = setTimeout(() => setShowConfirmation(false), 4000);
+    return () => clearTimeout(id);
+  }, [success, data?.name]);
 
   return (
     <ResponsiveFormContainer className={isMobile ? "" : "desktop"}>
@@ -226,7 +239,7 @@ export const CreateProductionPage = () => {
         isAddLineDisabled={hasDuplicateWithDefaultLine}
         isCreateDisabled={hasDuplicateWithDefaultLine}
       />
-      {success && data?.name && (
+      {showConfirmation && data?.name && (
         <>
           <ProductionConfirmation>
             The production <strong>{data.name}</strong> has been created.


### PR DESCRIPTION
[Ticket](https://github.com/orgs/EyevinnStudentDev/projects/3/views/1?pane=issue&itemId=144020509&issue=EyevinnStudentDev%7Cintercom-frontend%7C26)

Added a timer to the confirmation message when a production was created. It will show for 4 seconds, then disappear. 

Before, the production "FirstProduction" is still shown even when I'm working on creating a new production:
<img width="557" height="671" alt="Skärmavbild 2025-12-09 kl  12 08 37" src="https://github.com/user-attachments/assets/94abec96-1474-472b-b397-a0f6cf220acb" />

After (the message "FirstProduction" is gone after 4 seconds):
<img width="1120" height="1248" alt="image" src="https://github.com/user-attachments/assets/3fe22c66-64a4-4e3a-9f0d-91956388b59a" />


