### PR TITLE
fix: reverse ordering of calls

### DIFF
--- a/src/components/calls-page/calls-page.tsx
+++ b/src/components/calls-page/calls-page.tsx
@@ -94,9 +94,12 @@ export const CallsPage = () => {
 
   useEffect(() => {
     callIndexMap.current = {};
-    Object.keys(calls).forEach((callId, i) => {
-      callIndexMap.current[i + 1] = callId;
-    });
+    Object.keys(calls)
+      .slice()
+      .reverse()
+      .forEach((callId, i) => {
+        callIndexMap.current[i + 1] = callId;
+      });
   }, [calls]);
 
   usePreventPullToRefresh();

--- a/src/components/calls-page/production-lines.tsx
+++ b/src/components/calls-page/production-lines.tsx
@@ -35,26 +35,29 @@ export const ProductionLines = ({
 }: ProductionLinesProps) => {
   return (
     <>
-      {Object.entries(calls).map(
-        ([callId, callState]) =>
-          callId &&
-          callState.joinProductionOptions && (
-            <ProductionLine
-              key={callId}
-              id={callId}
-              shouldReduceVolume={shouldReduceVolume}
-              callState={callState}
-              isSingleCall={isSingleCall}
-              customGlobalMute={customGlobalMute}
-              masterInputMute={isMasterInputMuted}
-              setFailedToConnect={() => setAddCallActive(true)}
-              isSettingGlobalMute={isSettingGlobalMute}
-              callActionHandlers={callActionHandlers}
-              registerCallList={registerCallList}
-              deregisterCall={deregisterCall}
-            />
-          )
-      )}
+      {Object.entries(calls)
+        .slice()
+        .reverse()
+        .map(
+          ([callId, callState]) =>
+            callId &&
+            callState.joinProductionOptions && (
+              <ProductionLine
+                key={callId}
+                id={callId}
+                shouldReduceVolume={shouldReduceVolume}
+                callState={callState}
+                isSingleCall={isSingleCall}
+                customGlobalMute={customGlobalMute}
+                masterInputMute={isMasterInputMuted}
+                setFailedToConnect={() => setAddCallActive(true)}
+                isSettingGlobalMute={isSettingGlobalMute}
+                callActionHandlers={callActionHandlers}
+                registerCallList={registerCallList}
+                deregisterCall={deregisterCall}
+              />
+            )
+        )}
     </>
   );
 };


### PR DESCRIPTION
 Update the calls UI and keyboard index mapping so that newly created calls appear at the top of the list and are assigned the lowest numeric shortcut (1, 2, 3, …). This is done by reversing the iteration order of calls both when building callIndexMap and when rendering ProductionLines.