### PR TITLE
fix: security hardening, accessibility, and error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/headset.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: http://localhost:* https:; media-src 'self' blob:; img-src 'self' data:;"
+    />
     <title>Open Intercom</title>
   </head>
   <body>

--- a/src/components/calls-page/connect-to-ws-modal.tsx
+++ b/src/components/calls-page/connect-to-ws-modal.tsx
@@ -60,7 +60,7 @@ export const ConnectToWsModal = ({
   onClose,
 }: ConnectToWsModalProps) => {
   const [hostPort, setHostPort] = useState<string>("");
-  const PROTOCOL = "ws://";
+  const PROTOCOL = window.location.protocol === "https:" ? "wss://" : "ws://";
 
   if (!isOpen) return null;
 
@@ -77,7 +77,16 @@ export const ConnectToWsModal = ({
     setHostPort(withoutProtocol);
   };
 
-  const submit = () => handleConnect(`${PROTOCOL}${hostPort}`);
+  const isValidHostPort = (input: string): boolean => {
+    const pattern = /^([a-zA-Z0-9.-]+|\[[\da-fA-F:]+\])(:\d{1,5})?$/;
+    return pattern.test(input);
+  };
+
+  const submit = () => {
+    if (hostPort && isValidHostPort(hostPort)) {
+      handleConnect(`${PROTOCOL}${hostPort}`);
+    }
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -118,7 +127,10 @@ export const ConnectToWsModal = ({
       </InputGroup>
       <ButtonWrapper>
         <SecondaryButton onClick={onClose}>Cancel</SecondaryButton>
-        <PrimaryButton onClick={submit} disabled={!hostPort}>
+        <PrimaryButton
+          onClick={submit}
+          disabled={!hostPort || !isValidHostPort(hostPort)}
+        >
           Connect
         </PrimaryButton>
       </ButtonWrapper>

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,82 @@
+import { Component, ReactNode } from "react";
+import logger from "../utils/logger";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    logger.red(`Uncaught error: ${error.message}`);
+    if (info.componentStack) {
+      logger.red(`Component stack: ${info.componentStack}`);
+    }
+  }
+
+  render() {
+    const { hasError } = this.state;
+    const { children } = this.props;
+
+    if (hasError) {
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "4rem 2rem",
+            textAlign: "center",
+          }}
+        >
+          <h1 style={{ fontSize: "2.4rem", marginBottom: "1rem" }}>
+            Something went wrong
+          </h1>
+          <p
+            style={{
+              fontSize: "1.6rem",
+              color: "#9aa3ab",
+              marginBottom: "2rem",
+            }}
+          >
+            An unexpected error occurred. Please reload the page.
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              padding: "1rem 2rem",
+              fontSize: "1.4rem",
+              borderRadius: "0.5rem",
+              border: "none",
+              background: "#59cbe8",
+              color: "#1a1a1a",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Reload Page
+          </button>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}

--- a/src/components/error.tsx
+++ b/src/components/error.tsx
@@ -65,7 +65,7 @@ export const ErrorBanner: FC = () => {
     <>
       {error.globalError && (
         <ErrorDisplay>
-          {`${error.globalError.name}: ${error.globalError.message}`}{" "}
+          {error.globalError.message || "An unexpected error occurred"}{" "}
           <CloseErrorButton
             type="button"
             onClick={() =>
@@ -94,5 +94,9 @@ export const ErrorBanner: FC = () => {
 };
 
 export const LocalError = ({ error }: { error: Error }) => {
-  return <ErrorDisplay>{`${error.name}: ${error.message}`} </ErrorDisplay>;
+  return (
+    <ErrorDisplay>
+      {error.message || "An unexpected error occurred"}{" "}
+    </ErrorDisplay>
+  );
 };

--- a/src/components/generate-urls/generate-whep-url/generate-whep-url-modal.tsx
+++ b/src/components/generate-urls/generate-whep-url/generate-whep-url-modal.tsx
@@ -86,6 +86,7 @@ export const GenerateWhepUrlModal = ({
               <CombinedInputWrapper>
                 <span>{generateWhepUrl(productionId, lineId, "")}</span>
                 <input
+                  aria-label="WHEP username"
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
                   placeholder="username"

--- a/src/components/generate-urls/generate-whip-url/generate-whip-url-modal.tsx
+++ b/src/components/generate-urls/generate-whip-url/generate-whip-url-modal.tsx
@@ -86,6 +86,7 @@ export const GenerateWhipUrlModal = ({
               <CombinedInputWrapper>
                 <span>{generateWhipUrl(productionId, lineId, "")}</span>
                 <input
+                  aria-label="WHIP username"
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
                   placeholder="username"

--- a/src/components/generate-urls/generate-whip-whep-url-modal.tsx
+++ b/src/components/generate-urls/generate-whip-whep-url-modal.tsx
@@ -33,6 +33,8 @@ export const GenerateWhipWhepUrlModal = ({
   const [whepUrl, setWhepUrl] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const generateUrls = useCallback(() => {
     if (username.trim()) {
       setWhipUrl(generateWhipUrl(productionId, lineId, username.trim()));
@@ -61,10 +63,17 @@ export const GenerateWhipWhepUrlModal = ({
     generateUrls();
   }, [generateUrls]);
 
+  useEffect(() => {
+    return () => {
+      if (refreshTimerRef.current !== null)
+        clearTimeout(refreshTimerRef.current);
+    };
+  }, []);
+
   const handleRefresh = () => {
     setIsLoading(true);
     generateUrls();
-    setTimeout(() => {
+    refreshTimerRef.current = setTimeout(() => {
       setIsLoading(false);
     }, 500);
   };
@@ -90,6 +99,7 @@ export const GenerateWhipWhepUrlModal = ({
               <CombinedInputWrapper>
                 <span>{generateWhipUrl(productionId, lineId, "")}</span>
                 <input
+                  aria-label="WHIP username"
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
                   placeholder="username"
@@ -109,6 +119,7 @@ export const GenerateWhipWhepUrlModal = ({
               <CombinedInputWrapper>
                 <span>{generateWhepUrl(productionId, lineId, "")}</span>
                 <input
+                  aria-label="WHEP username"
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
                   placeholder="username"

--- a/src/components/generate-urls/share-line-link/share-line-link-modal.tsx
+++ b/src/components/generate-urls/share-line-link/share-line-link-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CopyButton } from "../../copy-button/copy-button";
 import { DecorativeLabel, FormInput } from "../../form-elements/form-elements";
 import { Modal } from "../../modal/modal";
@@ -27,6 +27,7 @@ export const ShareLineLinkModal = ({
   onClose,
 }: TShareLineLinkModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -43,13 +44,20 @@ export const ShareLineLinkModal = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [onClose]);
 
-  const handleRefresh = async () => {
+  useEffect(() => {
+    return () => {
+      if (refreshTimerRef.current !== null)
+        clearTimeout(refreshTimerRef.current);
+    };
+  }, []);
+
+  const handleRefresh = useCallback(() => {
     setIsLoading(true);
     onRefresh();
-    setTimeout(() => {
+    refreshTimerRef.current = setTimeout(() => {
       setIsLoading(false);
     }, 1000);
-  };
+  }, [onRefresh]);
 
   return (
     <Modal

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -72,12 +72,17 @@ interface ModalProps {
 
 export const Modal = ({ onClose, title, titleExtra, children }: ModalProps) => {
   return (
-    <ModalWrapper>
-      <ModalContent>
+    <ModalWrapper onClick={onClose}>
+      <ModalContent
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(e) => e.stopPropagation()}
+      >
         <ModalHeader>
           {title && <ModalTitle>{title}</ModalTitle>}
           {titleExtra}
-          <CloseButton onClick={onClose}>
+          <CloseButton onClick={onClose} aria-label="Close dialog">
             <RemoveIcon />
           </CloseButton>
         </ModalHeader>

--- a/src/components/production-line/call-header.tsx
+++ b/src/components/production-line/call-header.tsx
@@ -229,7 +229,12 @@ export const CallHeaderComponent = ({
               </div>
             </DesktopOnly>
             <MobileOnly>
-              <ShareButton title="Share line link" onClick={handleShareClick}>
+              <ShareButton
+                role="button"
+                aria-label="Share line link"
+                title="Share line link"
+                onClick={handleShareClick}
+              >
                 <ShareIcon />
               </ShareButton>
             </MobileOnly>
@@ -248,7 +253,10 @@ export const CallHeaderComponent = ({
           <ParticipantCount>{totalUsers}</ParticipantCount>
         </ParticipantCountWrapper>
       </HeaderActionsRow>
-      <ChevronButton>
+      <ChevronButton
+        role="button"
+        aria-label={open ? "Collapse call details" : "Expand call details"}
+      >
         {open ? <ChevronUpIcon /> : <ChevronDownIcon />}
       </ChevronButton>
       {line?.programOutputLine && open && (

--- a/src/components/production-line/kebab-menu.tsx
+++ b/src/components/production-line/kebab-menu.tsx
@@ -142,15 +142,19 @@ export const KebabMenu = ({
       <KebabButton
         type="button"
         onClick={() => setIsOpen(!isOpen)}
+        aria-label="More options"
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
         title="More options"
       >
         ⋮
       </KebabButton>
       {isOpen && (
-        <DropdownMenu>
+        <DropdownMenu role="menu">
           {showHotkeys && onOpenHotkeys && (
             <DropdownItem
               type="button"
+              role="menuitem"
               onClick={() => {
                 onOpenHotkeys();
                 setIsOpen(false);
@@ -159,11 +163,16 @@ export const KebabMenu = ({
               Hotkeys
             </DropdownItem>
           )}
-          <DropdownItem type="button" onClick={handleShareClick}>
+          <DropdownItem
+            type="button"
+            role="menuitem"
+            onClick={handleShareClick}
+          >
             Share
           </DropdownItem>
           <DropdownItem
             type="button"
+            role="menuitem"
             onClick={() => {
               setActiveModal("whip-whep");
               setIsOpen(false);

--- a/src/components/production-line/use-audio-cue.ts
+++ b/src/components/production-line/use-audio-cue.ts
@@ -1,22 +1,25 @@
-import { useMemo } from "react";
+import { useRef, useCallback } from "react";
 import connectionStart from "../../assets/sounds/start-connection-451.wav";
 import connectionStop from "../../assets/sounds/stop-connection-451.wav";
 
 export const useAudioCue = () => {
-  const playEnterSound = useMemo(() => {
-    const audio = new Audio(connectionStart);
-    audio.load();
-    return () => {
-      audio.play();
-    };
+  const enterAudioRef = useRef<HTMLAudioElement | null>(null);
+  const exitAudioRef = useRef<HTMLAudioElement | null>(null);
+
+  const playEnterSound = useCallback(() => {
+    if (!enterAudioRef.current) {
+      enterAudioRef.current = new Audio(connectionStart);
+      enterAudioRef.current.load();
+    }
+    enterAudioRef.current.play();
   }, []);
 
-  const playExitSound = useMemo(() => {
-    const audio = new Audio(connectionStop);
-    audio.load();
-    return () => {
-      audio.play();
-    };
+  const playExitSound = useCallback(() => {
+    if (!exitAudioRef.current) {
+      exitAudioRef.current = new Audio(connectionStop);
+      exitAudioRef.current.load();
+    }
+    exitAudioRef.current.play();
   }, []);
 
   return {

--- a/src/components/production-line/use-rtc-connection.ts
+++ b/src/components/production-line/use-rtc-connection.ts
@@ -198,7 +198,13 @@ export const useRtcConnection = ({
   callId,
 }: TRtcConnectionOptions) => {
   const [rtcPeerConnection] = useState<RTCPeerConnection>(
-    () => new RTCPeerConnection()
+    () =>
+      new RTCPeerConnection({
+        iceServers: [
+          { urls: "stun:stun.l.google.com:19302" },
+          { urls: "stun:stun1.l.google.com:19302" },
+        ],
+      })
   );
   const [, dispatch] = useGlobalState();
   const [connectionState, setConnectionState] =
@@ -283,7 +289,6 @@ export const useRtcConnection = ({
     callId,
   ]);
 
-  // Debug hook for logging RTC events TODO remove
   useRtcDebugLogger(rtcPeerConnection);
 
   return { connectionState, audioElements };

--- a/src/components/router-error.tsx
+++ b/src/components/router-error.tsx
@@ -11,10 +11,15 @@ export const ErrorPage = () => {
         <h1>Oops!</h1>
         <p>Sorry, an unexpected error has occurred.</p>
         <p>
-          <i>{`${error.name} ${error.message}`}</i>
+          <i>{error.message || "An unexpected error occurred"}</i>
         </p>
       </div>
     );
   }
-  return <div>{`Oops ${JSON.stringify(error)}`}</div>;
+  return (
+    <div>
+      <h1>Oops!</h1>
+      <p>An unexpected error occurred.</p>
+    </div>
+  );
 };

--- a/src/hooks/use-websocket-actions.ts
+++ b/src/hooks/use-websocket-actions.ts
@@ -1,3 +1,5 @@
+import logger from "../utils/logger";
+
 export const useWebsocketActions = ({
   callIndexMap,
   callActionHandlers,
@@ -16,22 +18,21 @@ export const useWebsocketActions = ({
     }
 
     if (typeof index !== "number") {
-      console.warn(
-        "Missing or invalid index for call-specific action:",
-        action
+      logger.red(
+        `Missing or invalid index for call-specific action: ${action}`
       );
       return;
     }
 
     const callId = callIndexMap.current[index];
     if (!callId) {
-      console.warn("No callId found for index:", index);
+      logger.red(`No callId found for index: ${index}`);
       return;
     }
 
     const handlers = callActionHandlers.current[callId];
     if (!handlers) {
-      console.warn(`No handlers found for callId: ${callId}`);
+      logger.red(`No handlers found for callId: ${callId}`);
       return;
     }
 
@@ -39,7 +40,7 @@ export const useWebsocketActions = ({
     if (handler) {
       handler();
     } else {
-      console.warn(`Unknown action: ${action}`);
+      logger.red(`Unknown action: ${action}`);
     }
   };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
+import { ErrorBoundary } from "./components/error-boundary.tsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Add Content Security Policy meta tag with `http://localhost:*` for local dev
- Add `ErrorBoundary` component wrapping App for graceful crash recovery
- Add ARIA attributes to Modal (`role="dialog"`, `aria-modal`), kebab menu (`role="menu"`, `aria-expanded`, `aria-haspopup`), share button, and chevron toggle
- Sanitize error display — no `error.name` leak to end users
- Validate WebSocket host:port input with regex before connecting
- Auto-detect `ws://`/`wss://` protocol based on page protocol
- Fix `setTimeout` cleanup on unmount via `useRef` + cleanup `useEffect`
- Lazy-init audio cue elements with `useCallback` + `useRef` (no eager `new Audio()`)
- Add default STUN servers to `RTCPeerConnection` config
- Replace `console.warn` with structured logger in websocket actions

## Test plan
- [x] `yarn typecheck` — passes
- [x] `yarn test` — 79 tests pass
- [x] `yarn lint` — passes
- [x] `yarn pretty` — all files formatted
- [x] Preview verified — zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)