### PR TITLE
fix: ui/ux fixes from deployment testing

### DIFF
--- a/src/api/handle-fetch-request.test.ts
+++ b/src/api/handle-fetch-request.test.ts
@@ -93,7 +93,7 @@ describe("handleFetchRequest", () => {
 
       await expect(
         handleFetchRequest(Promise.resolve(response))
-      ).rejects.toThrow("Response Code: 404");
+      ).rejects.toThrow("Error");
     });
 
     it("should attach the status code to the error object", async () => {

--- a/src/api/handle-fetch-request.ts
+++ b/src/api/handle-fetch-request.ts
@@ -25,7 +25,7 @@ export const handleFetchRequest = async <T>(
     } else if (json && "message" in json) {
       err = new Error(json.message);
     } else {
-      err = new Error(`Response Code: ${status} - ${response.statusText}.`);
+      err = new Error(response.statusText || "Unknown error");
     }
     (err as Error & { status?: number }).status = status;
     throw err;

--- a/src/bowser.ts
+++ b/src/bowser.ts
@@ -13,8 +13,6 @@ const isIOS = (): boolean => {
 export const isMobile = deviceInfo.platform.type === "mobile";
 export const isIOSMobile = isIOS() && isMobile;
 
-console.log(browser);
-
 export const isValidBrowser = browser.satisfies({
   chrome: ">=115",
   edge: ">=115",

--- a/src/components/calls-page/connect-to-ws-modal.tsx
+++ b/src/components/calls-page/connect-to-ws-modal.tsx
@@ -60,7 +60,7 @@ export const ConnectToWsModal = ({
   onClose,
 }: ConnectToWsModalProps) => {
   const [hostPort, setHostPort] = useState<string>("");
-  const PROTOCOL = window.location.protocol === "https:" ? "wss://" : "ws://";
+  const PROTOCOL = "ws://";
 
   if (!isOpen) return null;
 

--- a/src/components/error.tsx
+++ b/src/components/error.tsx
@@ -4,6 +4,27 @@ import { errorColour } from "../css-helpers/defaults";
 import { useGlobalState } from "../global-state/context-provider";
 import logger from "../utils/logger";
 
+const formatErrorMessage = (
+  error: (Error & { status?: number }) | null | undefined
+): string => {
+  if (!error) return "An unexpected error occurred";
+  const message = error.message || "An unexpected error occurred";
+  if (error.status) {
+    return `Error: ${error.status} - ${message}`;
+  }
+  return `Error: ${message}`;
+};
+
+const formatCallErrorMessage = (
+  message: string,
+  error: (Error & { status?: number }) | null | undefined
+): string => {
+  if (error?.status) {
+    return `Error: ${error.status} - ${message}`;
+  }
+  return `Error: ${message}`;
+};
+
 const ErrorDisplay = styled.div`
   width: 100%;
   background: ${errorColour};
@@ -37,9 +58,15 @@ export const ErrorBanner: FC = () => {
     const displayedMessages = new Set<string>();
     if (error.callErrors) {
       Object.entries(error.callErrors).forEach(([, singleError]) => {
-        if (singleError && !displayedMessages.has(singleError.message)) {
-          logger.red(`Error: ${singleError.message}`); // Display only unique errors
-          displayedMessages.add(singleError.message);
+        if (singleError) {
+          const formatted = formatCallErrorMessage(
+            singleError.message,
+            singleError as Error & { status?: number }
+          );
+          if (!displayedMessages.has(formatted)) {
+            logger.red(formatted);
+            displayedMessages.add(formatted);
+          }
         }
       });
       const uniqueErrors = Array.from(displayedMessages);
@@ -65,7 +92,7 @@ export const ErrorBanner: FC = () => {
     <>
       {error.globalError && (
         <ErrorDisplay>
-          {error.globalError.message || "An unexpected error occurred"}{" "}
+          {formatErrorMessage(error.globalError as Error & { status?: number })}{" "}
           <CloseErrorButton
             type="button"
             onClick={() =>
@@ -96,7 +123,7 @@ export const ErrorBanner: FC = () => {
 export const LocalError = ({ error }: { error: Error }) => {
   return (
     <ErrorDisplay>
-      {error.message || "An unexpected error occurred"}{" "}
+      {formatErrorMessage(error as Error & { status?: number })}{" "}
     </ErrorDisplay>
   );
 };

--- a/src/components/generate-urls/generate-whip-whep-url-modal.tsx
+++ b/src/components/generate-urls/generate-whip-whep-url-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState } from "react";
 import { generateWhipUrl } from "../../utils/generateWhipUrl";
 import { generateWhepUrl } from "../../utils/generateWhepUrl";
 import { CopyButton } from "../copy-button/copy-button";
@@ -28,22 +28,29 @@ export const GenerateWhipWhepUrlModal = ({
   onClose,
 }: TGenerateWhipWhepUrlModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
-  const [username, setUsername] = useState("");
+  const [whipUsername, setWhipUsername] = useState("");
+  const [whepUsername, setWhepUsername] = useState("");
   const [whipUrl, setWhipUrl] = useState("");
   const [whepUrl, setWhepUrl] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const generateUrls = useCallback(() => {
-    if (username.trim()) {
-      setWhipUrl(generateWhipUrl(productionId, lineId, username.trim()));
-      setWhepUrl(generateWhepUrl(productionId, lineId, username.trim()));
-    } else {
-      setWhipUrl("");
-      setWhepUrl("");
-    }
-  }, [username, productionId, lineId]);
+  useEffect(() => {
+    setWhipUrl(
+      whipUsername.trim()
+        ? generateWhipUrl(productionId, lineId, whipUsername.trim())
+        : ""
+    );
+  }, [whipUsername, productionId, lineId]);
+
+  useEffect(() => {
+    setWhepUrl(
+      whepUsername.trim()
+        ? generateWhepUrl(productionId, lineId, whepUsername.trim())
+        : ""
+    );
+  }, [whepUsername, productionId, lineId]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -60,10 +67,6 @@ export const GenerateWhipWhepUrlModal = ({
   }, [onClose]);
 
   useEffect(() => {
-    generateUrls();
-  }, [generateUrls]);
-
-  useEffect(() => {
     return () => {
       if (refreshTimerRef.current !== null)
         clearTimeout(refreshTimerRef.current);
@@ -72,7 +75,16 @@ export const GenerateWhipWhepUrlModal = ({
 
   const handleRefresh = () => {
     setIsLoading(true);
-    generateUrls();
+    setWhipUrl(
+      whipUsername.trim()
+        ? generateWhipUrl(productionId, lineId, whipUsername.trim())
+        : ""
+    );
+    setWhepUrl(
+      whepUsername.trim()
+        ? generateWhepUrl(productionId, lineId, whepUsername.trim())
+        : ""
+    );
     refreshTimerRef.current = setTimeout(() => {
       setIsLoading(false);
     }, 500);
@@ -100,8 +112,8 @@ export const GenerateWhipWhepUrlModal = ({
                 <span>{generateWhipUrl(productionId, lineId, "")}</span>
                 <input
                   aria-label="WHIP username"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
+                  value={whipUsername}
+                  onChange={(e) => setWhipUsername(e.target.value)}
                   placeholder="username"
                 />
               </CombinedInputWrapper>
@@ -120,8 +132,8 @@ export const GenerateWhipWhepUrlModal = ({
                 <span>{generateWhepUrl(productionId, lineId, "")}</span>
                 <input
                   aria-label="WHEP username"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
+                  value={whepUsername}
+                  onChange={(e) => setWhepUsername(e.target.value)}
                   placeholder="username"
                 />
               </CombinedInputWrapper>

--- a/src/components/production-line/call-header.tsx
+++ b/src/components/production-line/call-header.tsx
@@ -74,7 +74,6 @@ const HeaderActionsRow = styled.div`
   align-items: center;
   gap: 0.5rem;
   flex-shrink: 0;
-  margin-left: auto;
 `;
 
 const DesktopOnly = styled.div`
@@ -210,35 +209,23 @@ export const CallHeaderComponent = ({
       </CallHeaderTexts>
       <HeaderActionsRow>
         {production && line && (
-          <>
-            <DesktopOnly>
-              <div
-                onClick={(e) => e.stopPropagation()}
-                onMouseDown={(e) => e.stopPropagation()}
-                onKeyDown={(e) => e.stopPropagation()}
-                role="presentation"
-              >
-                <KebabMenu
-                  productionId={production.productionId}
-                  lineId={line.id}
-                  production={production}
-                  line={line}
-                  showHotkeys={showHotkeys}
-                  onOpenHotkeys={onOpenHotkeys}
-                />
-              </div>
-            </DesktopOnly>
-            <MobileOnly>
-              <ShareButton
-                role="button"
-                aria-label="Share line link"
-                title="Share line link"
-                onClick={handleShareClick}
-              >
-                <ShareIcon />
-              </ShareButton>
-            </MobileOnly>
-          </>
+          <DesktopOnly>
+            <div
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+              role="presentation"
+            >
+              <KebabMenu
+                productionId={production.productionId}
+                lineId={line.id}
+                production={production}
+                line={line}
+                showHotkeys={showHotkeys}
+                onOpenHotkeys={onOpenHotkeys}
+              />
+            </div>
+          </DesktopOnly>
         )}
         {totalWhipSessions > 0 && (
           <ParticipantCountWrapper
@@ -252,6 +239,18 @@ export const CallHeaderComponent = ({
           <UsersIcon />
           <ParticipantCount>{totalUsers}</ParticipantCount>
         </ParticipantCountWrapper>
+        {production && line && (
+          <MobileOnly>
+            <ShareButton
+              role="button"
+              aria-label="Share line link"
+              title="Share line link"
+              onClick={handleShareClick}
+            >
+              <ShareIcon />
+            </ShareButton>
+          </MobileOnly>
+        )}
       </HeaderActionsRow>
       <ChevronButton
         role="button"

--- a/src/components/production-line/select-devices.tsx
+++ b/src/components/production-line/select-devices.tsx
@@ -127,7 +127,12 @@ export const SelectDevices = ({
             <FormSelect
               // eslint-disable-next-line
               {...register(`audioinput`)}
-              defaultValue={joinProductionOptions.audioinput}
+              defaultValue={
+                joinProductionOptions.audioinput ??
+                devices.input?.find((d) => d.deviceId === "default")
+                  ?.deviceId ??
+                devices.input?.[0]?.deviceId
+              }
             >
               {devices.input && devices.input.length > 0 ? (
                 devices.input.map((device) => (

--- a/src/components/production-list/header-text.tsx
+++ b/src/components/production-list/header-text.tsx
@@ -1,6 +1,4 @@
-import { TLine } from "../production-line/types";
 import { TBasicProductionResponse } from "../../api/api";
-import { CopyLink } from "./copy-link";
 import {
   ProductionName,
   ProductionNameWrapper,
@@ -8,12 +6,8 @@ import {
 
 export const HeaderText = ({
   production,
-  line,
-  managementMode,
 }: {
   production: TBasicProductionResponse;
-  line: TLine;
-  managementMode: boolean;
 }) => {
   return (
     <ProductionNameWrapper>
@@ -22,9 +16,6 @@ export const HeaderText = ({
           ? `${production.name.slice(0, 40)}...`
           : production.name}
       </ProductionName>
-      {!managementMode && (
-        <CopyLink production={production} line={line} isCopyProduction />
-      )}
     </ProductionNameWrapper>
   );
 };

--- a/src/components/production-list/labelField.tsx
+++ b/src/components/production-list/labelField.tsx
@@ -15,11 +15,7 @@ export const LabelField = ({
   managementMode: boolean;
 }) => {
   return isLabelProductionName ? (
-    <HeaderText
-      production={production}
-      line={line}
-      managementMode={managementMode}
-    />
+    <HeaderText production={production} />
   ) : (
     <LineBlock managementMode={managementMode} line={line} />
   );

--- a/src/components/production-list/production-list-components.ts
+++ b/src/components/production-list/production-list-components.ts
@@ -22,7 +22,6 @@ export const ParticipantCountWrapper = styled.div`
   align-items: center;
   gap: 0.1rem;
   margin-right: 1rem;
-  transform: translateY(1.5px);
 
   svg {
     height: 1.5rem;

--- a/src/components/production-list/production-list-item.tsx
+++ b/src/components/production-list/production-list-item.tsx
@@ -11,6 +11,7 @@ import { CollapsibleItem } from "../shared/collapsible-item";
 import { LabelField } from "./labelField";
 import { ProductionListExpandedContent } from "./production-list-expanded-content";
 import { useHandleHeaderClick } from "../shared/use-handle-header-click";
+import { CopyLink } from "./copy-link";
 
 type ProductionsListItemProps = {
   production: TBasicProductionResponse;
@@ -57,7 +58,7 @@ export const ProductionsListItem = ({
           />
         )}
       />
-      <div>
+      <div style={{ display: "flex", alignItems: "center" }}>
         {totalWhipSessions > 0 && (
           <ParticipantCountWrapper
             className={totalWhipSessions > 0 ? "whip" : ""}
@@ -70,6 +71,13 @@ export const ProductionsListItem = ({
           <UsersIcon />
           <ParticipantCount>{totalUsers}</ParticipantCount>
         </ParticipantCountWrapper>
+        {!managementMode && (
+          <CopyLink
+            production={production}
+            line={production.lines?.[0] ?? ({} as TLine)}
+            isCopyProduction
+          />
+        )}
       </div>
     </>
   );

--- a/src/components/shared/shared-components.ts
+++ b/src/components/shared/shared-components.ts
@@ -14,8 +14,9 @@ export const HeaderWrapper = styled.div`
 export const HeaderTexts = styled.div`
   width: 100%;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
+  gap: 0.5rem;
   min-width: 0;
   overflow: hidden;
   margin-left: ${({

--- a/src/components/user-settings/user-settings.tsx
+++ b/src/components/user-settings/user-settings.tsx
@@ -32,7 +32,10 @@ export const UserSettings: FC<UserSettingsProps> = (props) => {
 
   const defaultValues = {
     username: userSettings?.username,
-    audioinput: userSettings?.audioinput,
+    audioinput:
+      userSettings?.audioinput ??
+      devices.input?.find((d) => d.deviceId === "default")?.deviceId ??
+      devices.input?.[0]?.deviceId,
     audiooutput: userSettings?.audiooutput,
   };
 


### PR DESCRIPTION
## Summary
- **Share icon alignment**: moved share icon out of production name wrapper, placed it next to participant counts, left-aligned with production/line name (both production cards and call header)
- **Unified error format**: centralized error display formatting in `error.tsx` — shows `Error: {status} - {message}` when a status code exists, otherwise `Error: {message}`. Cleaned up `handle-fetch-request.ts` to no longer prefix "Response Code:"
- **Default audio input**: first-time users (no saved settings) now default to the system "default" audio input device instead of whatever the browser lists first
- **WebSocket protocol**: hardcoded `ws://` for companion WebSocket connections — the companion module doesn't support WSS
- **WHIP/WHEP inputs**: split the shared username state into independent `whipUsername` and `whepUsername` so editing one no longer changes the other
- **Remove debug log**: removed `console.log(browser)` from `bowser.ts` that was logging the full Bowser parser object on every page load

## Changed files
| File | Change |
|------|--------|
| `src/components/production-list/header-text.tsx` | Removed CopyLink, simplified to only render production name |
| `src/components/production-list/labelField.tsx` | Updated HeaderText call (removed extra props) |
| `src/components/production-list/production-list-item.tsx` | Added CopyLink next to participant counts in header |
| `src/components/production-list/production-list-components.ts` | Removed `translateY(1.5px)` from ParticipantCountWrapper |
| `src/components/production-line/call-header.tsx` | Reordered participant counts before share button, removed `margin-left: auto` |
| `src/components/shared/shared-components.ts` | Changed HeaderTexts from `space-between` to `flex-start` |
| `src/components/error.tsx` | Added `formatErrorMessage` / `formatCallErrorMessage` helpers |
| `src/api/handle-fetch-request.ts` | Clean error message (no "Response Code:" prefix) |
| `src/api/handle-fetch-request.test.ts` | Updated test expectations for new error format |
| `src/components/user-settings/user-settings.tsx` | Default device fallback for first-time users |
| `src/components/production-line/select-devices.tsx` | Same default device fallback |
| `src/components/calls-page/connect-to-ws-modal.tsx` | Hardcoded `ws://` protocol |
| `src/components/generate-urls/generate-whip-whep-url-modal.tsx` | Split into `whipUsername` / `whepUsername` state |
| `src/bowser.ts` | Removed `console.log(browser)` |

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (9 files, 79 tests)
- [ ] Verify share icon appears next to participant counts on production cards
- [ ] Verify share icon appears next to participant counts on call header (mobile)
- [ ] Verify error banners show "Error: {code} - {message}" format
- [ ] Verify first-time users get system default audio device selected
- [ ] Verify companion WebSocket connects with `ws://` regardless of page protocol
- [ ] Verify WHIP and WHEP username inputs are independent in the URL modal
- [ ] Verify no browser object logged in console on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)