### PR TITLE
feat: add auto-join link sharing and companion auto-connect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,73 +108,70 @@ const AppContent = ({
           />
         </DisplayBoxPositioningContainer>
       )}
-      {continueToApp && (
-        <>
-          {denied && (
-            <DisplayBoxPositioningContainer>
-              <DisplayWarning
-                text="To use this application it has to be granted access to audio devices. Reload browser and/or reset permissions to try
-            again."
-                title="Permissions have been denied"
-              />
-            </DisplayBoxPositioningContainer>
-          )}
-          {!permission && !denied && (
-            <DisplayBoxPositioningContainer>
-              <DisplayWarning
-                text="To use this application it has to be granted access to audio devices."
-                title="Waiting for device permissions"
-              />
-            </DisplayBoxPositioningContainer>
-          )}
-          {apiError && (
-            <DisplayBoxPositioningContainer>
-              <DisplayWarning
-                text="The server is not available. Reload page to try again."
-                title="Server not available"
-              />
-            </DisplayBoxPositioningContainer>
-          )}
-          {permission && !denied && !apiError && userSettings && (
-            <Routes>
-              <>
-                <Route
-                  path="/"
-                  element={
-                    <LandingPage setApiError={() => setApiError(true)} />
-                  }
-                  errorElement={<ErrorPage />}
-                />
-                <Route
-                  path="/create-production"
-                  element={<CreateProductionPage />}
-                  errorElement={<ErrorPage />}
-                />
-                <Route
-                  path="/manage-productions"
-                  element={
-                    <ManageProductionsPage
-                      setApiError={() => setApiError(true)}
-                    />
-                  }
-                  errorElement={<ErrorPage />}
-                />
-                <Route
-                  path="/auto-join"
-                  element={<AutoJoinPage />}
-                  errorElement={<ErrorPage />}
-                />
-                <Route
-                  path="/production-calls/production/:productionId/line/:lineId"
-                  element={<CallsPage />}
-                  errorElement={<ErrorPage />}
-                />
-                <Route path="*" element={<NotFound />} />
-              </>
-            </Routes>
-          )}
-        </>
+      {continueToApp && denied && (
+        <DisplayBoxPositioningContainer>
+          <DisplayWarning
+            text="To use this application it has to be granted access to audio devices. Reload browser and/or reset permissions to try again."
+            title="Permissions have been denied"
+          />
+        </DisplayBoxPositioningContainer>
       )}
+      {continueToApp && !permission && !denied && (
+        <DisplayBoxPositioningContainer>
+          <DisplayWarning
+            text="To use this application it has to be granted access to audio devices."
+            title="Waiting for device permissions"
+          />
+        </DisplayBoxPositioningContainer>
+      )}
+      {continueToApp && apiError && (
+        <DisplayBoxPositioningContainer>
+          <DisplayWarning
+            text="The server is not available. Reload page to try again."
+            title="Server not available"
+          />
+        </DisplayBoxPositioningContainer>
+      )}
+
+      <Routes>
+        {permission && !denied && !apiError && userSettings && (
+          <>
+            <Route
+              path="/"
+              element={<LandingPage setApiError={() => setApiError(true)} />}
+              errorElement={<ErrorPage />}
+            />
+            <Route
+              path="/create-production"
+              element={<CreateProductionPage />}
+              errorElement={<ErrorPage />}
+            />
+            <Route
+              path="/manage-productions"
+              element={
+                <ManageProductionsPage setApiError={() => setApiError(true)} />
+              }
+              errorElement={<ErrorPage />}
+            />
+            <Route
+              path="/auto-join"
+              element={<AutoJoinPage />}
+              errorElement={<ErrorPage />}
+            />
+            <Route
+              path="/production-calls"
+              element={<CallsPage />}
+              errorElement={<ErrorPage />}
+            />
+            <Route
+              path="/production-calls/production/:productionId/line/:lineId"
+              element={<CallsPage />}
+              errorElement={<ErrorPage />}
+            />
+          </>
+        )}
+        <Route path="*" element={<NotFound />} />
+      </Routes>
     </BrowserRouter>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { ManageProductionsPage } from "./components/manage-productions-page/mana
 import { CreateProductionPage } from "./components/create-production/create-production-page.tsx";
 import { useSetupTokenRefresh } from "./hooks/use-reauth.tsx";
 import { TUserSettings } from "./components/user-settings/types";
+import { AutoJoinPage } from "./components/auto-join/auto-join-page.tsx";
 
 const DisplayBoxPositioningContainer = styled(FlexContainer)`
   justify-content: center;
@@ -156,6 +157,11 @@ const AppContent = ({
                       setApiError={() => setApiError(true)}
                     />
                   }
+                  errorElement={<ErrorPage />}
+                />
+                <Route
+                  path="/auto-join"
+                  element={<AutoJoinPage />}
                   errorElement={<ErrorPage />}
                 />
                 <Route

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,9 +1,12 @@
 import { handleFetchRequest } from "./handle-fetch-request.ts";
 
-const API_VERSION = import.meta.env.VITE_BACKEND_API_VERSION ?? "api/v1/";
-const API_URL =
-  `${import.meta.env.VITE_BACKEND_URL.replace(/\/+$/, "")}/${API_VERSION}` ||
-  `${window.location.origin}/${API_VERSION}`;
+const API_VERSION = (
+  import.meta.env.VITE_BACKEND_API_VERSION ?? "api/v1"
+).replace(/\/+$/, "");
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
+const API_URL = BACKEND_URL
+  ? `${BACKEND_URL.replace(/\/+$/, "")}/${API_VERSION}/`
+  : `${window.location.origin}/${API_VERSION}/`;
 const API_KEY = import.meta.env.VITE_BACKEND_API_KEY;
 
 type TCreateProductionOptions = {

--- a/src/components/auto-join/auto-join-link-modal.tsx
+++ b/src/components/auto-join/auto-join-link-modal.tsx
@@ -35,7 +35,10 @@ type TAutoJoinLinkModalProps = {
   onClose: () => void;
 };
 
-export const AutoJoinLinkModal = ({ url, onClose }: TAutoJoinLinkModalProps) => {
+export const AutoJoinLinkModal = ({
+  url,
+  onClose,
+}: TAutoJoinLinkModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [includeCompanion, setIncludeCompanion] = useState(false);
 
@@ -43,7 +46,10 @@ export const AutoJoinLinkModal = ({ url, onClose }: TAutoJoinLinkModalProps) => 
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node)
+      ) {
         onClose();
       }
     };
@@ -56,7 +62,8 @@ export const AutoJoinLinkModal = ({ url, onClose }: TAutoJoinLinkModalProps) => 
       <div ref={modalRef}>
         <ModalHeader>Auto Join Link</ModalHeader>
         <ModalText>
-          Share this link to let someone join the same set of calls automatically.
+          Share this link to let someone join the same set of calls
+          automatically.
         </ModalText>
         <CheckboxRow>
           <input

--- a/src/components/auto-join/auto-join-link-modal.tsx
+++ b/src/components/auto-join/auto-join-link-modal.tsx
@@ -43,7 +43,9 @@ export const AutoJoinLinkModal = ({
   const [includeCompanion, setIncludeCompanion] = useState(false);
   const [username, setUsername] = useState("");
 
-  const usernameParam = username ? `&username=${encodeURIComponent(username)}` : "";
+  const usernameParam = username
+    ? `&username=${encodeURIComponent(username)}`
+    : "";
   const displayUrl = `${url}${usernameParam}${includeCompanion ? COMPANION_SUFFIX : ""}`;
 
   useEffect(() => {

--- a/src/components/auto-join/auto-join-link-modal.tsx
+++ b/src/components/auto-join/auto-join-link-modal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import { CopyButton } from "../copy-button/copy-button";
-import { FormInput } from "../form-elements/form-elements";
+import { DecorativeLabel, FormInput } from "../form-elements/form-elements";
 import { Modal } from "../modal/modal";
 import {
   InputWrapper,
@@ -41,8 +41,10 @@ export const AutoJoinLinkModal = ({
 }: TAutoJoinLinkModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [includeCompanion, setIncludeCompanion] = useState(false);
+  const [username, setUsername] = useState("");
 
-  const displayUrl = includeCompanion ? `${url}${COMPANION_SUFFIX}` : url;
+  const usernameParam = username ? `&username=${encodeURIComponent(username)}` : "";
+  const displayUrl = `${url}${usernameParam}${includeCompanion ? COMPANION_SUFFIX : ""}`;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -65,6 +67,19 @@ export const AutoJoinLinkModal = ({
           Share this link to let someone join the same set of calls
           automatically.
         </ModalText>
+        <Wrapper>
+          <InputWrapper>
+            <LinkLabel>
+              <DecorativeLabel>Username (optional)</DecorativeLabel>
+              <FormInput
+                type="text"
+                placeholder="Leave empty to use saved settings"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+              />
+            </LinkLabel>
+          </InputWrapper>
+        </Wrapper>
         <CheckboxRow>
           <input
             type="checkbox"

--- a/src/components/auto-join/auto-join-link-modal.tsx
+++ b/src/components/auto-join/auto-join-link-modal.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from "react";
+import styled from "@emotion/styled";
+import { CopyButton } from "../copy-button/copy-button";
+import { FormInput } from "../form-elements/form-elements";
+import { Modal } from "../modal/modal";
+import {
+  InputWrapper,
+  LinkLabel,
+  ModalHeader,
+  ModalText,
+  Wrapper,
+} from "../generate-urls/generate-urls-components";
+
+const CheckboxRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 1.4rem;
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  margin-top: 1.5rem;
+
+  input[type="checkbox"] {
+    width: 1.6rem;
+    height: 1.6rem;
+    cursor: pointer;
+    accent-color: #59cbe8;
+  }
+`;
+
+const COMPANION_SUFFIX = "&companion=ws://127.0.0.1:12345";
+
+type TAutoJoinLinkModalProps = {
+  url: string;
+  onClose: () => void;
+};
+
+export const AutoJoinLinkModal = ({ url, onClose }: TAutoJoinLinkModalProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [includeCompanion, setIncludeCompanion] = useState(false);
+
+  const displayUrl = includeCompanion ? `${url}${COMPANION_SUFFIX}` : url;
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onClose]);
+
+  return (
+    <Modal onClose={onClose}>
+      <div ref={modalRef}>
+        <ModalHeader>Auto Join Link</ModalHeader>
+        <ModalText>
+          Share this link to let someone join the same set of calls automatically.
+        </ModalText>
+        <CheckboxRow>
+          <input
+            type="checkbox"
+            checked={includeCompanion}
+            onChange={(e) => setIncludeCompanion(e.target.checked)}
+          />
+          Include companion connection
+        </CheckboxRow>
+        <Wrapper>
+          <InputWrapper>
+            <LinkLabel>
+              <FormInput readOnly value={displayUrl} />
+            </LinkLabel>
+            <CopyButton urls={[displayUrl]} className="share-line-link-modal" />
+          </InputWrapper>
+        </Wrapper>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/auto-join/auto-join-page.tsx
+++ b/src/components/auto-join/auto-join-page.tsx
@@ -42,9 +42,9 @@ export const AutoJoinPage = () => {
     const audioinput =
       userSettings?.audioinput || devices?.input?.[0]?.deviceId;
 
-    const joinAll = async () => {
-      for (const call of calls) {
-        await initiateProductionCall({
+    Promise.all(
+      calls.map((call) =>
+        initiateProductionCall({
           payload: {
             joinProductionOptions: {
               productionId: call.productionId,
@@ -56,12 +56,9 @@ export const AutoJoinPage = () => {
             },
             audiooutput,
           },
-        });
-      }
-      navigate("/production-calls");
-    };
-
-    joinAll();
+        })
+      )
+    ).then(() => navigate("/production-calls"));
   }, [searchParams, userSettings, devices, navigate, initiateProductionCall]);
 
   return null;

--- a/src/components/auto-join/auto-join-page.tsx
+++ b/src/components/auto-join/auto-join-page.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+import { useSearchParams, useNavigate } from "react-router";
+import { useGlobalState } from "../../global-state/context-provider";
+import { useInitiateProductionCall } from "../../hooks/use-initiate-production-call";
+import { AUTO_JOIN_STORAGE_KEY, TAutoJoinCall } from "../../utils/auto-join";
+
+export const AutoJoinPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [{ userSettings, devices }, dispatch] = useGlobalState();
+  const { initiateProductionCall } = useInitiateProductionCall({ dispatch });
+  const hasInitiated = useRef(false);
+
+  useEffect(() => {
+    if (hasInitiated.current) return;
+
+    const callsParam = searchParams.get("calls") ?? "";
+    const usernameParam = searchParams.get("username");
+    const companionParam = searchParams.get("companion");
+    const username = usernameParam || userSettings?.username || "Auto";
+
+    const calls: TAutoJoinCall[] = callsParam
+      .split(",")
+      .map((pair) => pair.split(":"))
+      .filter(([p, l]) => p && l)
+      .map(([productionId, lineId]) => ({ productionId, lineId }));
+
+    if (calls.length === 0) {
+      navigate("/");
+      return;
+    }
+
+    hasInitiated.current = true;
+
+    localStorage.setItem(AUTO_JOIN_STORAGE_KEY, JSON.stringify(calls));
+
+    if (companionParam) {
+      localStorage.setItem("companion_auto_connect", companionParam);
+    }
+
+    const audiooutput = userSettings?.audiooutput;
+    const audioinput =
+      userSettings?.audioinput || devices?.input?.[0]?.deviceId;
+
+    const joinAll = async () => {
+      for (const call of calls) {
+        await initiateProductionCall({
+          payload: {
+            joinProductionOptions: {
+              productionId: call.productionId,
+              lineId: call.lineId,
+              username,
+              audioinput,
+              lineUsedForProgramOutput: false,
+              isProgramUser: false,
+            },
+            audiooutput,
+          },
+        });
+      }
+      navigate("/production-calls");
+    };
+
+    joinAll();
+  }, [searchParams, userSettings, devices, navigate, initiateProductionCall]);
+
+  return null;
+};

--- a/src/components/calls-page/calls-page.tsx
+++ b/src/components/calls-page/calls-page.tsx
@@ -1,8 +1,12 @@
 import styled from "@emotion/styled";
 import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router";
+import { ShareIcon } from "../../assets/icons/icon";
 import { useGlobalState } from "../../global-state/context-provider";
+import { useAutoJoinRestore } from "../../hooks/use-auto-join-restore";
 import { useCallList } from "../../hooks/use-call-list";
+import { AutoJoinLinkModal } from "../auto-join/auto-join-link-modal";
+import { CopyIconWrapper } from "../copy-button/copy-components";
 import { JoinProduction } from "../landing-page/join-production";
 import { UserSettingsButton } from "../landing-page/user-settings-button";
 import { Modal } from "../modal/modal";
@@ -46,6 +50,7 @@ const CallsContainer = styled.div`
 export const CallsPage = () => {
   const [productionId, setProductionId] = useState<string | null>(null);
   const [addCallActive, setAddCallActive] = useState<boolean>(false);
+  const [autoJoinModalOpen, setAutoJoinModalOpen] = useState<boolean>(false);
   const [confirmExitModalOpen, setConfirmExitModalOpen] =
     useState<boolean>(false);
   const [isMasterInputMuted, setIsMasterInputMuted] = useState<boolean>(true);
@@ -64,8 +69,19 @@ export const CallsPage = () => {
   const [showSettings, setShowSettings] = useState<boolean>(false);
   const [isSettingGlobalMute, setIsSettingGlobalMute] =
     useState<boolean>(false);
+  const [companionAutoConnectUrl, setCompanionAutoConnectUrl] = useState<
+    string | null
+  >(null);
 
   const { productionId: paramProductionId, lineId: paramLineId } = useParams();
+
+  useEffect(() => {
+    const storedCompanionUrl = localStorage.getItem("companion_auto_connect");
+    if (storedCompanionUrl && !companionAutoConnectUrl) {
+      setCompanionAutoConnectUrl(storedCompanionUrl);
+      localStorage.removeItem("companion_auto_connect");
+    }
+  }, [companionAutoConnectUrl]);
 
   const navigate = useCallsNavigation({
     isEmpty: Object.values(calls).length === 0,
@@ -106,6 +122,7 @@ export const CallsPage = () => {
   }, [calls]);
 
   usePreventPullToRefresh();
+  useAutoJoinRestore();
 
   useEffect(() => {
     if (selectedProductionId) {
@@ -151,6 +168,34 @@ export const CallsPage = () => {
       )}
       <PageHeader
         title={!isEmpty ? "Calls" : ""}
+        titleAction={
+          !isEmpty ? (
+            <>
+              <CopyIconWrapper
+                title="Share auto-join link"
+                onClick={() => setAutoJoinModalOpen(true)}
+                style={{ marginTop: "2px", marginLeft: "2px" }}
+              >
+                <ShareIcon />
+              </CopyIconWrapper>
+              {autoJoinModalOpen && (
+                <AutoJoinLinkModal
+                  url={`${window.location.origin}/auto-join?calls=${Object.values(
+                    calls
+                  )
+                    .map((c) => {
+                      const { productionId: pid, lineId: lid } =
+                        c.joinProductionOptions ?? {};
+                      return pid && lid ? `${pid}:${lid}` : null;
+                    })
+                    .filter(Boolean)
+                    .join(",")}`}
+                  onClose={() => setAutoJoinModalOpen(false)}
+                />
+              )}
+            </>
+          ) : undefined
+        }
         hasNavigateToRoot
         onNavigateToRoot={() => {
           if (isEmpty) {
@@ -193,6 +238,7 @@ export const CallsPage = () => {
           callActionHandlers={callActionHandlers}
           sendCallsStateUpdate={sendCallsStateUpdate}
           resetLastSentCallsState={resetLastSentCallsState}
+          companionAutoConnectUrl={companionAutoConnectUrl}
         />
       </PageHeader>
       <Container>

--- a/src/components/calls-page/connect-to-ws-button.tsx
+++ b/src/components/calls-page/connect-to-ws-button.tsx
@@ -71,6 +71,7 @@ interface ConnectToWSButtonProps {
     Record<string, Record<string, () => void>>
   >;
   isMasterInputMuted: boolean;
+  companionAutoConnectUrl: string | null;
   handleToggleGlobalMute: () => void;
   sendCallsStateUpdate: () => void;
   resetLastSentCallsState: () => void;
@@ -80,6 +81,7 @@ export const ConnectToWSButton = ({
   callIndexMap,
   callActionHandlers,
   isMasterInputMuted,
+  companionAutoConnectUrl,
   handleToggleGlobalMute,
   sendCallsStateUpdate,
   resetLastSentCallsState,
@@ -88,6 +90,7 @@ export const ConnectToWSButton = ({
   const [isWSReconnecting, setIsWSReconnecting] = useState(false);
   const [isConnectionConflict, setConnectionConflict] = useState(false);
   const [{ calls }, dispatch] = useGlobalState();
+  const [hasAutoConnected, setHasAutoConnected] = useState(false);
 
   // map call ids to indices for actions
   useEffect(() => {
@@ -128,6 +131,22 @@ export const ConnectToWSButton = ({
     setIsWSReconnecting,
     wsConnect,
   });
+
+  // Auto-connect to Companion if companionAutoConnectUrl is provided
+  useEffect(() => {
+    if (hasAutoConnected || isWSConnected || !companionAutoConnectUrl) {
+      return;
+    }
+
+    setHasAutoConnected(true);
+
+    if (
+      companionAutoConnectUrl.startsWith("ws://") ||
+      companionAutoConnectUrl.startsWith("wss://")
+    ) {
+      wsConnect(companionAutoConnectUrl);
+    }
+  }, [hasAutoConnected, isWSConnected, companionAutoConnectUrl, wsConnect]);
 
   const handleConnect = (url: string) => {
     setConnectionConflict(false);

--- a/src/components/calls-page/header-actions.tsx
+++ b/src/components/calls-page/header-actions.tsx
@@ -52,6 +52,7 @@ type HeaderActionsProps = {
   callActionHandlers: React.MutableRefObject<
     Record<string, Record<string, () => void>>
   >;
+  companionAutoConnectUrl: string | null;
   setIsMasterInputMuted: React.Dispatch<React.SetStateAction<boolean>>;
   setAddCallActive: (addCallActive: boolean) => void;
   setIsSettingGlobalMute: React.Dispatch<React.SetStateAction<boolean>>;
@@ -66,6 +67,7 @@ export const HeaderActions = ({
   callIndexMap,
   callActionHandlers,
   addCallActive,
+  companionAutoConnectUrl,
   setAddCallActive,
   setIsSettingGlobalMute,
   sendCallsStateUpdate,
@@ -86,6 +88,7 @@ export const HeaderActions = ({
           sendCallsStateUpdate={sendCallsStateUpdate}
           resetLastSentCallsState={resetLastSentCallsState}
           handleToggleGlobalMute={handleToggleGlobalMute}
+          companionAutoConnectUrl={companionAutoConnectUrl}
         />
       )}
       {!isEmpty && !isSingleCall && !isMobile && (

--- a/src/components/page-layout/page-header.tsx
+++ b/src/components/page-layout/page-header.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { FC, PropsWithChildren } from "react";
+import { FC, PropsWithChildren, ReactNode } from "react";
 import { DisplayContainer } from "../generic-components";
 import { DisplayContainerHeader } from "../landing-page/display-container-header";
 import { LoaderDots } from "../loader/loader";
@@ -54,6 +54,7 @@ const RootButtonWrapper = styled.div`
 
 interface PageHeaderProps extends PropsWithChildren {
   title: string;
+  titleAction?: ReactNode;
   hasNavigateToRoot?: boolean;
   onNavigateToRoot?: () => void;
   loading?: boolean;
@@ -62,6 +63,7 @@ interface PageHeaderProps extends PropsWithChildren {
 export const PageHeader: FC<PageHeaderProps> = (props) => {
   const {
     title,
+    titleAction,
     hasNavigateToRoot = false,
     onNavigateToRoot,
     loading = false,
@@ -77,6 +79,7 @@ export const PageHeader: FC<PageHeaderProps> = (props) => {
           </RootButtonWrapper>
         )}
         <CustomContainerHeader>{title}</CustomContainerHeader>
+        {titleAction}
         <LoaderWrapper>
           <LoaderDots className={loading ? "active" : "in-active"} />
         </LoaderWrapper>

--- a/src/hooks/use-auto-join-restore.ts
+++ b/src/hooks/use-auto-join-restore.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from "react";
+import { useGlobalState } from "../global-state/context-provider";
+import { useInitiateProductionCall } from "./use-initiate-production-call";
+import { AUTO_JOIN_STORAGE_KEY, TAutoJoinCall } from "../utils/auto-join";
+
+export const useAutoJoinRestore = () => {
+  const [{ calls, userSettings, devices }, dispatch] = useGlobalState();
+  const { initiateProductionCall } = useInitiateProductionCall({ dispatch });
+  const callsWereActive = useRef(false);
+  const hasRestored = useRef(false);
+
+  // On mount: restore calls if localStorage has a saved config and state is empty
+  useEffect(() => {
+    if (hasRestored.current) return;
+
+    const stored = localStorage.getItem(AUTO_JOIN_STORAGE_KEY);
+    if (!stored || Object.keys(calls).length > 0) return;
+
+    let savedCalls: TAutoJoinCall[];
+    try {
+      savedCalls = JSON.parse(stored);
+    } catch {
+      localStorage.removeItem(AUTO_JOIN_STORAGE_KEY);
+      return;
+    }
+
+    if (savedCalls.length === 0) return;
+
+    hasRestored.current = true;
+
+    const username = userSettings?.username || "Auto";
+    const audiooutput = userSettings?.audiooutput;
+    const audioinput =
+      userSettings?.audioinput || devices?.input?.[0]?.deviceId;
+
+    savedCalls.forEach((call) => {
+      initiateProductionCall({
+        payload: {
+          joinProductionOptions: {
+            productionId: call.productionId,
+            lineId: call.lineId,
+            username,
+            audioinput,
+            lineUsedForProgramOutput: false,
+            isProgramUser: false,
+          },
+          audiooutput,
+        },
+      });
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Clear stored config when the user intentionally empties all calls
+  useEffect(() => {
+    if (Object.keys(calls).length > 0) {
+      callsWereActive.current = true;
+    } else if (callsWereActive.current) {
+      localStorage.removeItem(AUTO_JOIN_STORAGE_KEY);
+      callsWereActive.current = false;
+    }
+  }, [calls]);
+};

--- a/src/hooks/use-call-list.ts
+++ b/src/hooks/use-call-list.ts
@@ -100,7 +100,9 @@ export function useCallList({
           ((data.isProgramOutputLine && !data.isProgramUser) ||
             !data.isProgramOutputLine)) ||
         prev.volume !== data.volume ||
-        prev.isSomeoneSpeaking !== data.isSomeoneSpeaking;
+        prev.isSomeoneSpeaking !== data.isSomeoneSpeaking ||
+        prev.lineName !== data.lineName ||
+        prev.productionName !== data.productionName;
 
       if (!hasChanged) return;
 

--- a/src/utils/auto-join.ts
+++ b/src/utils/auto-join.ts
@@ -1,0 +1,6 @@
+export const AUTO_JOIN_STORAGE_KEY = "auto_join_calls";
+
+export type TAutoJoinCall = {
+  productionId: string;
+  lineId: string;
+};


### PR DESCRIPTION
- Add /auto-join route that joins calls from URL params
- Add share icon next to "Calls" title opening an auto-join link modal
- Auto-join link modal optionally appends a companion WebSocket URL
- Add useAutoJoinRestore hook to restore calls from localStorage on reload
- Add companionAutoConnectUrl to ConnectToWSButton for auto-connecting WS
- Add titleAction prop to PageHeader for injecting content next to title