### PR TITLE
fix(reauth): stop reauth retries and hourly refresh on 405

### DIFF
--- a/src/hooks/use-reauth.test.tsx
+++ b/src/hooks/use-reauth.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSetupTokenRefresh } from "./use-reauth";
+import { API } from "../api/api";
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("../api/api", () => ({
+  API: {
+    reauth: vi.fn(),
+  },
+}));
+
+const mockDispatch = vi.fn();
+vi.mock("../global-state/context-provider", () => ({
+  useGlobalState: vi.fn(() => [{}, mockDispatch]),
+}));
+
+const mockAPI = API as unknown as {
+  reauth: ReturnType<typeof vi.fn>;
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeStatusError = (status: number, message = "error") => {
+  const error = new Error(message) as Error & { status?: number };
+  error.status = status;
+  return error;
+};
+
+// `setupTokenRefresh` bails out immediately when `import.meta.env.DEV` is
+// true, which is Vitest's default. Stub it to false so the reauth logic
+// under test actually runs (mirrors production/preview builds).
+describe("useSetupTokenRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("DEV", false);
+    mockDispatch.mockClear();
+    mockAPI.reauth.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("on 405, calls API.reauth exactly once, dispatches no ERROR, and clears the hourly interval permanently", async () => {
+    mockAPI.reauth.mockRejectedValue(
+      makeStatusError(405, "Method Not Allowed")
+    );
+
+    const { result } = renderHook(() => useSetupTokenRefresh());
+
+    await act(async () => {
+      result.current.setupTokenRefresh();
+      // Flush the immediately-invoked reauth() call (no sleeps expected)
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(mockAPI.reauth).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    // Advance well past the hourly interval — if it were still armed,
+    // API.reauth would be called again
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2 * 60 * 60 * 1000);
+    });
+
+    expect(mockAPI.reauth).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it("on a non-405 failure (403), still retries 3 times and dispatches the ERROR", async () => {
+    mockAPI.reauth.mockRejectedValue(makeStatusError(403, "Forbidden"));
+
+    const { result } = renderHook(() => useSetupTokenRefresh());
+
+    await act(async () => {
+      result.current.setupTokenRefresh();
+      await vi.advanceTimersByTimeAsync(2 * 3000);
+    });
+
+    expect(mockAPI.reauth).toHaveBeenCalledTimes(3);
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "ERROR",
+      payload: {
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            "Failed to reauth after 3 attempts - 403"
+          ),
+        }),
+      },
+    });
+  });
+
+  it("on 500, still retries 3 times but suppresses the ERROR dispatch (existing behaviour)", async () => {
+    mockAPI.reauth.mockRejectedValue(
+      makeStatusError(500, "Internal Server Error")
+    );
+
+    const { result } = renderHook(() => useSetupTokenRefresh());
+
+    await act(async () => {
+      result.current.setupTokenRefresh();
+      await vi.advanceTimersByTimeAsync(2 * 3000);
+    });
+
+    expect(mockAPI.reauth).toHaveBeenCalledTimes(3);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it("on success, dispatches no error and schedules the hourly interval", async () => {
+    mockAPI.reauth.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSetupTokenRefresh());
+
+    await act(async () => {
+      result.current.setupTokenRefresh();
+      // Flush only the initial immediately-invoked reauth() call, without
+      // advancing the clock (avoids also firing the hourly interval tick)
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockAPI.reauth).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    // Interval should still be armed and fire again after an hour
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    });
+
+    expect(mockAPI.reauth).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/use-reauth.tsx
+++ b/src/hooks/use-reauth.tsx
@@ -22,6 +22,14 @@ const attemptReauth = async (): Promise<Error | null> => {
       return null;
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
+      const { status } = lastError as Error & { status?: number };
+      const is405Error = status === 405 || lastError.message.includes("405");
+      if (is405Error) {
+        // 405 means this backend doesn't implement /reauth (not behind OSC) —
+        // this is a definitive signal, not a transient failure, so don't burn
+        // the remaining attempts or sleeps
+        return lastError;
+      }
       if (attempt < REAUTH_MAX_ATTEMPTS) {
         // eslint-disable-next-line no-await-in-loop
         await sleep(REAUTH_RETRY_DELAY_MS);
@@ -57,6 +65,16 @@ export const useSetupTokenRefresh = () => {
         const is500Error = status === 500 || lastError.message.includes("500");
         if (is500Error) {
           // Don't dispatch 500 errors as they're expected when initial OSC token expires
+          return;
+        }
+        const is405Error = status === 405 || lastError.message.includes("405");
+        if (is405Error) {
+          // This backend doesn't implement /reauth (not behind OSC) — stop
+          // trying permanently, no error banner, no console noise
+          if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+          }
           return;
         }
         const codePart = status != null ? status.toString() : "";


### PR DESCRIPTION
## Summary
- Backends not deployed behind Eyevinn OSC have no `OSC_ACCESS_TOKEN`, so `GET /api/v1/reauth` deliberately returns 405 — this is intentional, documented backend behaviour (see the JSDoc in intercom-manager's `src/api_re_auth.ts`), not an error to fix on that side.
- `useSetupTokenRefresh` only special-cased 500 responses, so a 405 burned all 3 retries (3s apart), then dispatched a global `ERROR` action that rendered the red banner on every page load — and repeated hourly via the token-refresh interval.
- Root cause is a frontend/backend status-code mismatch: the frontend treated every non-500 failure as a real, retryable/reportable error, when 405 is actually a definitive "this backend doesn't implement reauth" signal.
- Fix: `attemptReauth` now short-circuits after a single attempt on 405, and `useSetupTokenRefresh` dispatches nothing and clears the hourly interval so it never fires again for that session. 500 suppression and all other error handling are unchanged.
- No backend change and no new env var/API contract — the frontend is the correct side to fix.

## Test plan
- [x] `npm test` — 145/145 passing, including 4 new tests in `src/hooks/use-reauth.test.tsx`:
  - 405 → `API.reauth` called exactly once, no `ERROR` dispatch, hourly interval cleared permanently
  - 403 (non-405, non-500) → still retries 3 times and still dispatches the `ERROR`
  - 500 → still retries 3 times but suppresses the dispatch (existing behaviour, unchanged)
  - success → no dispatch, hourly interval still scheduled
- [x] The 405 test was verified load-bearing by reverting the fix locally — it fails with 4 `API.reauth` calls instead of 1, confirming it actually exercises the new short-circuit path.
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run pretty` idempotent (no diff)
- [ ] No e2e test was added intentionally: `playwright.config.ts` sets `webServer.command: npm run dev`, so `import.meta.env.DEV` is `true` in e2e runs and `setupTokenRefresh` returns early before any of this logic executes. An e2e test of this path would pass regardless of whether the fix is present, so unit tests are the only meaningful coverage here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)