### PR TITLE
chore: release 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "intercom-frontend",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "intercom-frontend",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intercom-frontend",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps the version in `package.json` and `package-lock.json` from 4.0.0 to 4.1.0 in preparation for the v4.1.0 release.

## Included since v4.0.0

- `feat(ui)`: rename Line/Lines to Call/Calls (#620)
- `fix(reauth)`: stop retries and hourly refresh on 405 (#669)
- `fix`: vitest CVE (CVSS 9.8) (#654)
- Plus assorted dependency chores

## Test plan

- Version-only change; no source code touched
- CI (lint, typecheck, test, build) validates the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)